### PR TITLE
Fix "source" not being reassigned

### DIFF
--- a/ElvUI/Core/Modules/Nameplates/StyleFilter.lua
+++ b/ElvUI/Core/Modules/Nameplates/StyleFilter.lua
@@ -360,7 +360,7 @@ function mod:StyleFilterAuraCheck(frame, names, tickers, filter, mustHaveAll, mi
 				end
 
 				index = index + 1
-				name, _, count, _, _, expiration, _, _, _, spellID = UnitAura(frame.unit, index, filter)
+				name, _, count, _, _, expiration, source, _, _, spellID = UnitAura(frame.unit, index, filter)
 			end
 
 			local stale = matches + 1


### PR DESCRIPTION
Buffs and debuffs would bleed through the style filter because source was not being reevaluated correctly which would result in the FromMe/FromPet filters not applying correctly and triggering on buffs/debuffs from other players if you are in combat with the same target. This PR fixes that.