### PR TITLE
TBC nameplate threat color

### DIFF
--- a/ElvUI/Core/Modules/Nameplates/Nameplates.lua
+++ b/ElvUI/Core/Modules/Nameplates/Nameplates.lua
@@ -516,11 +516,15 @@ function NP:GROUP_ROSTER_UPDATE()
 
 	wipe(NP.GroupRoles)
 
-	if NP.IsInGroup and E.Retail then
+	if NP.IsInGroup then
 		local Unit = (isInRaid and 'raid') or 'party'
 		for i = 1, ((isInRaid and GetNumGroupMembers()) or GetNumSubgroupMembers()) do
 			if UnitExists(Unit .. i) then
-				NP.GroupRoles[UnitName(Unit .. i)] = UnitGroupRolesAssigned(Unit .. i)
+				if E.Retail then
+					NP.GroupRoles[UnitName(Unit .. i)] = UnitGroupRolesAssigned(Unit .. i)
+				else
+					NP.GroupRoles[UnitName(Unit .. i)] = (GetPartyAssignment('MAINTANK', Unit .. i) and 'TANK') or 'NONE'
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Hi, I'm enjoying this awesome addon playing wow classic TBC but recently I started tanking as well and was missing this functionality from retail.

This will correctly set the player role to tank if in raid and the player is marked as main tank and it will correctly show threat colors of the enemy nameplates if offtank has aggro or other player manages to take the aggro.