### PR TITLE
No sound alert during chat history display

### DIFF
--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -3576,7 +3576,12 @@ function CH:Initialize()
 		end
 	end
 
-	if CH.db.chatHistory then CH:DisplayChatHistory() end
+	if CH.db.chatHistory then
+		-- ensure no keyword alert sounds are played during the loading of the chat history
+		CH.SoundTimer = true
+		CH:DisplayChatHistory()
+		CH.ThrottleSound()
+	end
 	CH:BuildCopyChatFrame()
 
 	-- Editbox Backdrop Color


### PR DESCRIPTION
I have non-combat keywords set to play a whisper sound when my name is mentioned: `%MYNAME%, Lin, Lina, Linaori`, and I also have a rather large history. which often means that I get a whisper sound when my loading screen is about to finish.

![image](https://user-images.githubusercontent.com/1754678/154839948-40701993-62b1-4ab7-8ed3-d5a9f15eebe5.png)

This change will suppress any sounds played from keywords when loading the history. I'm not 100% sure if this is the way to go, mainly because there's no reset if loading the history fails. I don't think that keyword sounds are your biggest problem if that happens though.
