### PR TITLE
Fix Dispellable information for TBC

### DIFF
--- a/ElvUI/Core/General/API.lua
+++ b/ElvUI/Core/General/API.lua
@@ -187,8 +187,6 @@ end
 function E:CheckRole()
 	E.myspec = GetSpecialization()
 	E.myrole = E:GetPlayerRole()
-
-	E:UpdateDispelClasses()
 end
 
 do -- keep this synced with oUF_AuraHighlight and oUF_RaidDebuffs


### PR DESCRIPTION
Running E:UpdateDispelClasses() in E:CheckRole() results in elseif at line 230 giving inaccurate information for TBC, as this check is intended to only be run in retail (line 632)