### PR TITLE
Fix minimap anchor when scaling

### DIFF
--- a/ElvUI/Core/Modules/Maps/Minimap.lua
+++ b/ElvUI/Core/Modules/Maps/Minimap.lua
@@ -301,7 +301,7 @@ function M:UpdateSettings()
 	local mmOffset = E.PixelMode and 1 or 3
 	local mmScale = E.db.general.minimap.scale
 	Minimap:ClearAllPoints()
-	Minimap:Point('TOPRIGHT', MMHolder, 'TOPRIGHT', -mmOffset, -mmOffset)
+	Minimap:Point('TOPRIGHT', MMHolder, 'TOPRIGHT', -mmOffset/mmScale, -mmOffset/mmScale)
 	Minimap:Size(E.MinimapSize, E.MinimapSize)
 	Minimap:SetScale(mmScale)
 


### PR DESCRIPTION
Prevent the minimap from shifting left a pixel when scaling up to 200%