### PR TITLE
Chat box fixes and classic range check improvement

### DIFF
--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -2526,7 +2526,7 @@ function CH:UpdateChatKeywords()
 
 	for stringValue in gmatch(keywords, '[^,]+') do
 		if stringValue ~= '' then
-			CH.Keywords[stringValue] = true
+			CH.Keywords[stringValue == "%MYNAME%" and E.myname or stringValue] = true
 		end
 	end
 end

--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -827,10 +827,6 @@ function CH:StyleChat(frame)
 	editbox:HookScript('OnEditFocusGained', CH.EditBoxFocusGained)
 	editbox:HookScript('OnEditFocusLost', CH.EditBoxFocusLost)
 
-	for _, text in pairs(editbox.historyLines) do
-		editbox:AddHistoryLine(text)
-	end
-
 	--copy chat button
 	local copyButton = CreateFrame('Frame', format('ElvUI_CopyChatButton%d', id), frame)
 	copyButton:EnableMouse(true)

--- a/ElvUI/Libraries/Core/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/ElvUI/Libraries/Core/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -288,6 +288,7 @@ tinsert(HarmSpells.WARLOCK, 5782)		-- Fear (30 yards)
 if not isRetail then
 	tinsert(HarmSpells.WARLOCK, 172)	-- Corruption (30 yards, level 4, rank 1)
 	tinsert(HarmSpells.WARLOCK, 348)	-- Immolate (30 yards, level 1, rank 1)
+	tinsert(HarmSpells.WARLOCK, 17877)		-- Shadowburn (Destruction) (20 yards)
 end
 
 tinsert(ResSpells.WARLOCK, 20707)	-- Soulstone (40 yards)


### PR DESCRIPTION
You can witness the chat edit history being shuffled by observing the ChatEditHistory table in character savedvars. It should be scrambled on UI reload.

The %MYNAME% keyword is referenced here: https://github.com/tukui-org/ElvUI/blob/development/ElvUI_OptionsUI/Chat.lua#L79

I've tested changes ingame. I can confirm that I have more granular range checking on my warlock when Shadowburn is included in the harmful spell list.