### PR TITLE
Fixes chat edit history getting shuffled

### DIFF
--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -816,7 +816,6 @@ function CH:StyleChat(frame)
 	editbox:SetAltArrowKeyMode(CH.db.useAltKey)
 	editbox:SetAllPoints(_G.LeftChatDataPanel)
 	editbox:HookScript('OnTextChanged', CH.EditBoxOnTextChanged)
-	CH:SecureHook(editbox, 'AddHistoryLine', 'ChatEdit_AddHistory')
 
 	--Work around broken SetAltArrowKeyMode API
 	editbox.historyLines = ElvCharacterDB.ChatEditHistory
@@ -827,9 +826,11 @@ function CH:StyleChat(frame)
 	editbox:HookScript('OnEditFocusGained', CH.EditBoxFocusGained)
 	editbox:HookScript('OnEditFocusLost', CH.EditBoxFocusLost)
 
-	for _, text in ipairs(editbox.historyLines) do
-		editbox:AddHistoryLine(text)
-	end
+	-- Don't need to do this since SetAltArrowKeyMode is broken
+	-- for _, text in ipairs(editbox.historyLines) do
+	-- 	editbox:AddHistoryLine(text)
+	-- end
+	CH:SecureHook(editbox, 'AddHistoryLine', 'ChatEdit_AddHistory')
 
 	--copy chat button
 	local copyButton = CreateFrame('Frame', format('ElvUI_CopyChatButton%d', id), frame)


### PR DESCRIPTION
Amends 042fbb0 as described by a1819c7

Yes, it is still getting shuffled. You can witness the bug as described in #272
TL;DR: Reload UI. ChatEditHistory in character SavedVars is now reordered. It shouldn't be doing that.

It can be fixed either by removing the AddHistoryLine block, or by hooking AddHistoryLine *after* that section. Both should probably be done anyway, so I've done both. Reminder that the default EditBox history is overwritten by ElvUI and is never used (ElvUI also wipes it constantly), so removing AddHistoryLine does not break chat edit history.