### PR TITLE
Adding Dual Spec Datatext

### DIFF
--- a/ElvUI/Wrath/Modules/DataTexts/DualSpec.lua
+++ b/ElvUI/Wrath/Modules/DataTexts/DualSpec.lua
@@ -1,0 +1,102 @@
+local E, L, V, P, G = unpack(ElvUI)
+local DT = E:GetModule('DataTexts')
+
+local _G = _G
+local ipairs, wipe = ipairs, wipe
+local format, next, strjoin = format, next, strjoin
+local HideUIPanel = HideUIPanel
+local IsShiftKeyDown = IsShiftKeyDown
+local ShowUIPanel = ShowUIPanel
+
+local TALENTS = TALENTS
+local LEVEL_UP_DUALSPEC = LEVEL_UP_DUALSPEC
+local MAX_TALENT_TABS = MAX_TALENT_TABS
+local PRIMARY = PRIMARY
+local SECONDARY = SECONDARY
+
+local GetActiveTalentGroup = GetActiveTalentGroup
+local GetNumTalentGroups = GetNumTalentGroups
+local SetActiveTalentGroup = SetActiveTalentGroup
+local GetTalentTabInfo = GetTalentTabInfo
+
+
+local function BuildTalentString(talentGroup)
+	local str = ''
+
+	for i = 1, MAX_TALENT_TABS do
+		local pointsSpent = select(3, GetTalentTabInfo(i, false, false, talentGroup));
+		if (str == '') then
+			str = pointsSpent
+		else
+			str = strjoin('/', str, pointsSpent)
+		end
+	end
+
+	return str
+end
+
+local displayString, lastPanel = ''
+local function OnEvent(self, event)
+	lastPanel = self
+
+	local activeGroup = GetActiveTalentGroup()
+	local str = BuildTalentString(activeGroup)
+
+	if E.global.datatexts.settings.DualSpec.NoLabel then
+		self.text:SetFormattedText('%s', str)
+	else
+		self.text:SetFormattedText('%s: %s', activeGroup == 1 and PRIMARY or SECONDARY, str)
+	end
+end
+
+local function OnEnter()
+	local activeGroup = GetActiveTalentGroup()
+
+	if activeGroup == 1 then
+		DT.tooltip:AddLine(SPECIALIZATION_PRIMARY_ACTIVE)
+		DT.tooltip:AddLine(SPECIALIZATION_SECONDARY)
+	else
+		DT.tooltip:AddLine(SPECIALIZATION_PRIMARY)
+		DT.tooltip:AddLine(SPECIALIZATION_SECONDARY_ACTIVE)
+	end
+	-- thinking something like (active highlighted in green)
+	--[[
+		Primary: 56/3/12
+		Secondary: 18/0/53
+	]]
+
+
+
+	DT.tooltip:AddLine(' ')
+	DT.tooltip:AddLine(L["|cffFFFFFFLeft Click:|r Change Talent Specialization"])
+	DT.tooltip:AddLine(L["|cffFFFFFFShift + Left Click:|r Show Talent Specialization UI"])
+	DT.tooltip:Show()
+end
+
+local function OnClick(self, button)
+	if button == 'LeftButton' then
+		if not _G.PlayerTalentFrame then
+			_G.LoadAddOn('Blizzard_TalentUI')
+		end
+		if IsShiftKeyDown() then
+			if not _G.PlayerTalentFrame:IsShown() then
+				ShowUIPanel(_G.PlayerTalentFrame)
+			else
+				HideUIPanel(_G.PlayerTalentFrame)
+			end
+		else
+			if GetNumTalentGroups() == 2 then
+				SetActiveTalentGroup(GetActiveTalentGroup() == 1 and 2 or 1)
+			end
+		end
+	end
+end
+
+local function ValueColorUpdate(hex)
+	displayString = strjoin('', E.global.datatexts.settings.DualSpec.NoLabel and '' or '%s', hex, '%d|r')
+
+	if lastPanel then OnEvent(lastPanel) end
+end
+E.valueColorUpdateFuncs[ValueColorUpdate] = true
+
+DT:RegisterDatatext('Dual Specialization', nil, { 'CHARACTER_POINTS_CHANGED', 'ACTIVE_TALENT_GROUP_CHANGED' }, OnEvent, nil, OnClick, OnEnter, nil, LEVEL_UP_DUALSPEC)

--- a/ElvUI/Wrath/Modules/DataTexts/DualSpec.lua
+++ b/ElvUI/Wrath/Modules/DataTexts/DualSpec.lua
@@ -35,6 +35,10 @@ local function BuildTalentString(talentGroup)
 	return str
 end
 
+local function ColorText(str, hex)
+	return format('|cff%s%s|r',hex,str)
+end
+
 local displayString, lastPanel = ''
 local function OnEvent(self, event)
 	lastPanel = self
@@ -42,30 +46,23 @@ local function OnEvent(self, event)
 	local activeGroup = GetActiveTalentGroup()
 	local str = BuildTalentString(activeGroup)
 
-	if E.global.datatexts.settings.DualSpec.NoLabel then
-		self.text:SetFormattedText('%s', str)
+	if E.global.datatexts.settings.DualSpec and E.global.datatexts.settings.DualSpec.NoLabel then
+		self.text:SetFormattedText(displayString, str)
 	else
-		self.text:SetFormattedText('%s: %s', activeGroup == 1 and PRIMARY or SECONDARY, str)
+		self.text:SetFormattedText(displayString, activeGroup == 1 and PRIMARY or SECONDARY, str)
 	end
 end
 
 local function OnEnter()
 	local activeGroup = GetActiveTalentGroup()
 
-	if activeGroup == 1 then
-		DT.tooltip:AddLine(SPECIALIZATION_PRIMARY_ACTIVE)
-		DT.tooltip:AddLine(SPECIALIZATION_SECONDARY)
-	else
-		DT.tooltip:AddLine(SPECIALIZATION_PRIMARY)
-		DT.tooltip:AddLine(SPECIALIZATION_SECONDARY_ACTIVE)
+	local primaryStr = BuildTalentString(1)
+	DT.tooltip:AddDoubleLine(activeGroup == 1 and ColorText(SPECIALIZATION_PRIMARY, '0CD809') or ColorText(SPECIALIZATION_PRIMARY, 'FFFFFF'), activeGroup == 1 and ColorText(primaryStr, '0CD809') or ColorText(primaryStr, 'FFFFFF'))
+
+	if GetNumTalentGroups() == 2 then
+		local secondaryStr = BuildTalentString(2)
+		DT.tooltip:AddDoubleLine(activeGroup == 2 and ColorText(SPECIALIZATION_SECONDARY, '0CD809') or ColorText(SPECIALIZATION_SECONDARY, 'FFFFFF'), activeGroup == 2 and ColorText(secondaryStr, '0CD809') or ColorText(secondaryStr, 'FFFFFF'))
 	end
-	-- thinking something like (active highlighted in green)
-	--[[
-		Primary: 56/3/12
-		Secondary: 18/0/53
-	]]
-
-
 
 	DT.tooltip:AddLine(' ')
 	DT.tooltip:AddLine(L["|cffFFFFFFLeft Click:|r Change Talent Specialization"])
@@ -93,7 +90,7 @@ local function OnClick(self, button)
 end
 
 local function ValueColorUpdate(hex)
-	displayString = strjoin('', E.global.datatexts.settings.DualSpec.NoLabel and '' or '%s', hex, '%d|r')
+	displayString = strjoin('', E.global.datatexts.settings.DualSpec and E.global.datatexts.settings.DualSpec.NoLabel and '' or '%s: ', hex, '%s|r')
 
 	if lastPanel then OnEvent(lastPanel) end
 end

--- a/ElvUI/Wrath/Modules/DataTexts/Load_DataTexts.xml
+++ b/ElvUI/Wrath/Modules/DataTexts/Load_DataTexts.xml
@@ -9,4 +9,5 @@
 	<Script file='..\..\..\Core\Modules\DataTexts\SpellHit.lua'/>
 	<Script file='..\..\..\Core\Modules\DataTexts\SpellHaste.lua'/>
 	<Script file='..\..\..\Core\Modules\DataTexts\SpellPower.lua'/>
+	<Script file='DualSpec.lua'/>
 </Ui>


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/18713839/189513980-078510f9-a0d8-4d60-9c2a-02ee5fe08f4b.png)

On character without dual spec:
![image](https://user-images.githubusercontent.com/18713839/189514001-b879bd88-2558-4fd4-ac0d-fd788df360ce.png)

On character below level 10 (could change this to be `N/A`?):
![image](https://user-images.githubusercontent.com/18713839/189514034-13fa700e-19bd-450d-b8de-d380cf8ff01a.png)


Something to note:
I can not remember the proper way to add the NoLabel global for a datatext that is only in Wrath, so I will leave that to whomever wants to do it.