### PR TITLE
Fix Intellect DT's default label

### DIFF
--- a/ElvUI/Core/Modules/DataTexts/Intellect.lua
+++ b/ElvUI/Core/Modules/DataTexts/Intellect.lua
@@ -21,7 +21,7 @@ local function OnEvent(self)
 end
 
 local function ValueColorUpdate(hex)
-	displayString = strjoin('', E.global.datatexts.settings.Intellect.NoLabel and '' or '%s: ', hex, '%.f|r')
+	displayString = strjoin('', E.global.datatexts.settings.Intellect.NoLabel and '' or '%s', hex, '%.f|r')
 
 	if lastPanel then OnEvent(lastPanel) end
 end


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/18713839/189514130-3420ffc4-3d37-4a90-b582-044ae0840bd9.png)

Changed to match how the other ability datatexts are coded.