### PR TITLE
Use LibClassicSpecs GetSpecialization in LibDualSpec

### DIFF
--- a/ElvUI/Libraries/Core/LibDualSpec-1.0/LibDualSpec-1.0.lua
+++ b/ElvUI/Libraries/Core/LibDualSpec-1.0/LibDualSpec-1.0.lua
@@ -85,7 +85,9 @@ if isRetail then
 	end
 end
 
-local GetSpecialization = GetSpecialization or GetActiveTalentGroup
+local LCS = LibStub('LibClassicSpecs-ElvUI', true)
+
+local GetSpecialization = (LCS and LCS.GetSpecialization) or GetSpecialization or GetActiveTalentGroup
 local CanPlayerUseTalentSpecUI = isRetail and C_SpecializationInfo.CanPlayerUseTalentSpecUI or function()
 	return true, HELPFRAME_CHARACTER_BULLET5
 end


### PR DESCRIPTION
I was getting the following error in Wrath:

```
Message: ...I\Libraries\Core\LibDualSpec-1.0\LibDualSpec-1.0.lua:470: attempt to compare number with string
Time: Fri Oct 14 14:50:22 2022
Count: 2
Stack: ...I\Libraries\Core\LibDualSpec-1.0\LibDualSpec-1.0.lua:470: attempt to compare number with string
[string "=[C]"]: ?
[string "@Interface\AddOns\ElvUI\Libraries\Core\LibDualSpec-1.0\LibDualSpec-1.0.lua"]:470: in function <...I\Libraries\Core\LibDualSpec-1.0\LibDualSpec-1.0.lua:451>

Locals: 
```

The global GetSpecialization function was returning the spec ID as a string. Using the LibClassicSpecs version if it exists fixed the error.