### PR TITLE
Fix bank border on first load

### DIFF
--- a/ElvUI/Core/Modules/Bags/Bags.lua
+++ b/ElvUI/Core/Modules/Bags/Bags.lua
@@ -2205,6 +2205,7 @@ function B:OpenBank()
 	_G.BankFrame:Show()
 
 	if B.BankFrame.firstOpen then
+		B:UpdateLayout(B.BankFrame)
 		B:UpdateAllSlots(B.BankFrame)
 		B.BankFrame.firstOpen = nil
 	elseif next(B.BankFrame.staleBags) then


### PR DESCRIPTION
bank slots were missing data on first load like `assigned` and `type`