### PR TITLE
Fix Tooltip OnTooltipSet and Bag Sort

### DIFF
--- a/ElvUI/Core/Modules/Bags/Bags.lua
+++ b/ElvUI/Core/Modules/Bags/Bags.lua
@@ -836,14 +836,14 @@ end
 
 function B:UpdateCooldown(slot)
 	local start, duration, enabled = GetContainerItemCooldown(slot.BagID, slot.SlotID)
-	if duration > 0 and enabled == 0 then
+	if duration and duration > 0 and enabled == 0 then
 		SetItemButtonTextureVertexColor(slot, 0.4, 0.4, 0.4)
 	else
 		SetItemButtonTextureVertexColor(slot, 1, 1, 1)
 	end
 
 	local cd = slot.Cooldown
-	if duration > 0 and enabled == 1 then
+	if duration and duration > 0 and enabled == 1 then
 		local newStart, newDuration = not cd.start or cd.start ~= start, not cd.duration or cd.duration ~= duration
 		if newStart or newDuration then
 			cd:SetCooldown(start, duration)

--- a/ElvUI/Core/Modules/Bags/Sort.lua
+++ b/ElvUI/Core/Modules/Bags/Sort.lua
@@ -7,12 +7,6 @@ local strmatch, gmatch, strfind = strmatch, gmatch, strfind
 local tinsert, tremove, sort, wipe = tinsert, tremove, sort, wipe
 local tonumber, floor, band = tonumber, floor, bit.band
 
-local ContainerIDToInventoryID = ContainerIDToInventoryID
-local GetContainerItemID = GetContainerItemID
-local GetContainerItemInfo = GetContainerItemInfo
-local GetContainerItemLink = GetContainerItemLink
-local GetContainerNumFreeSlots = GetContainerNumFreeSlots
-local GetContainerNumSlots = GetContainerNumSlots
 local GetCurrentGuildBankTab = GetCurrentGuildBankTab
 local GetCursorInfo = GetCursorInfo
 local GetGuildBankItemInfo = GetGuildBankItemInfo
@@ -23,10 +17,8 @@ local GetItemFamily = GetItemFamily
 local GetItemInfo = GetItemInfo
 local GetTime = GetTime
 local InCombatLockdown = InCombatLockdown
-local PickupContainerItem = PickupContainerItem
 local PickupGuildBankItem = PickupGuildBankItem
 local QueryGuildBankTab = QueryGuildBankTab
-local SplitContainerItem = SplitContainerItem
 local SplitGuildBankItem = SplitGuildBankItem
 
 local NUM_BAG_SLOTS = NUM_BAG_SLOTS
@@ -36,6 +28,37 @@ local BANK_CONTAINER = BANK_CONTAINER
 local C_PetJournalGetPetInfoBySpeciesID = C_PetJournal and C_PetJournal.GetPetInfoBySpeciesID
 local ItemClass_Armor = Enum.ItemClass.Armor
 local ItemClass_Weapon = Enum.ItemClass.Weapon
+
+local ContainerIDToInventoryID = ContainerIDToInventoryID
+local GetContainerItemID = GetContainerItemID
+local GetContainerItemLink = GetContainerItemLink
+local GetContainerNumFreeSlots = GetContainerNumFreeSlots
+local GetContainerNumSlots = GetContainerNumSlots
+local PickupContainerItem = PickupContainerItem
+local SplitContainerItem = SplitContainerItem
+
+-- converted below
+local GetContainerItemInfo
+
+do
+	local container = E.wowtoc >= 100002 and C_Container -- WoW 10.0.2
+	if container then
+		ContainerIDToInventoryID = container.ContainerIDToInventoryID
+		GetContainerItemID = container.GetContainerItemID
+		GetContainerItemInfo = container.GetContainerItemInfo
+		GetContainerItemLink = container.GetContainerItemLink
+		GetContainerNumFreeSlots = container.GetContainerNumFreeSlots
+		GetContainerNumSlots = container.GetContainerNumSlots
+		PickupContainerItem = container.PickupContainerItem
+		SplitContainerItem = container.SplitContainerItem
+	else -- localised above
+		GetContainerItemInfo = function(containerIndex, slotIndex)
+			local info = {}
+			info.iconFileID, info.stackCount, info.isLocked, info.quality, info.isReadable, info.hasLoot, info.hyperlink, info.isFiltered, info.hasNoValue, info.itemID, info.isBound = _G.GetContainerItemInfo(containerIndex, slotIndex)
+			return info
+		end
+	end
+end
 
 local guildBags = {51,52,53,54,55,56,57,58}
 local bankBags = {BANK_CONTAINER}
@@ -421,7 +444,10 @@ function B:GetItemInfo(bag, slot)
 	if IsGuildBankBag(bag) then
 		return GetGuildBankItemInfo(bag - 50, slot)
 	else
-		return GetContainerItemInfo(bag, slot)
+		local info = GetContainerItemInfo(bag, slot)
+		if info then
+			return info.iconFileID, info.stackCount, info.isLocked
+		end
 	end
 end
 

--- a/ElvUI/Core/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Core/Modules/Tooltip/Tooltip.lua
@@ -972,13 +972,32 @@ function TT:Initialize()
 	TT:SecureHook(GameTooltip, 'SetUnitAura')
 	TT:SecureHook(GameTooltip, 'SetUnitBuff', 'SetUnitAura')
 	TT:SecureHook(GameTooltip, 'SetUnitDebuff', 'SetUnitAura')
-	TT:SecureHookScript(GameTooltip, 'OnTooltipSetSpell', 'GameTooltip_OnTooltipSetSpell')
 	TT:SecureHookScript(GameTooltip, 'OnTooltipCleared', 'GameTooltip_OnTooltipCleared')
-	TT:SecureHookScript(GameTooltip, 'OnTooltipSetItem', 'GameTooltip_OnTooltipSetItem')
-	TT:SecureHookScript(GameTooltip, 'OnTooltipSetUnit', 'GameTooltip_OnTooltipSetUnit')
 	TT:SecureHookScript(GameTooltip.StatusBar, 'OnValueChanged', 'GameTooltipStatusBar_OnValueChanged')
-	TT:SecureHookScript(_G.ElvUISpellBookTooltip, 'OnTooltipSetSpell', 'GameTooltip_OnTooltipSetSpell')
 	TT:RegisterEvent('MODIFIER_STATE_CHANGED')
+
+	if E.wowtoc >= 100002 then
+		TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(tooltip)
+			if tooltip == GameTooltip then
+				TT:GameTooltip_OnTooltipSetItem(tooltip)
+			end
+		end)
+		TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Spell, function(tooltip)
+			if tooltip == GameTooltip or tooltip == _G.ElvUISpellBookTooltip then
+				TT:GameTooltip_OnTooltipSetSpell(tooltip)
+			end
+		end)
+		TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Unit, function(tooltip)
+			if tooltip == GameTooltip then
+				TT:GameTooltip_OnTooltipSetUnit(tooltip)
+			end
+		end)
+	else
+		TT:SecureHookScript(GameTooltip, 'OnTooltipSetSpell', 'GameTooltip_OnTooltipSetSpell')
+		TT:SecureHookScript(GameTooltip, 'OnTooltipSetItem', 'GameTooltip_OnTooltipSetItem')
+		TT:SecureHookScript(GameTooltip, 'OnTooltipSetUnit', 'GameTooltip_OnTooltipSetUnit')
+		TT:SecureHookScript(_G.ElvUISpellBookTooltip, 'OnTooltipSetSpell', 'GameTooltip_OnTooltipSetSpell')
+	end
 
 	if E.Retail then
 		TT:SecureHook('EmbeddedItemTooltip_SetSpellWithTextureByID', 'EmbeddedItemTooltip_ID')


### PR DESCRIPTION
Fix Tooltip OnTooltipSet and Bag Sort for 10.0.2

* use TooltipDataProcessor.AddTooltipPostCall for
  * OnTooltipSetSpell
  * OnTooltipSetItem
  * OnTooltipSetUnit
* Copy C_Container workarounds to Sort and use new C_Container.GetContainerItemInfo