### PR TITLE
Add missing arena castbar position options

### DIFF
--- a/ElvUI/Core/Defaults/Profile.lua
+++ b/ElvUI/Core/Defaults/Profile.lua
@@ -2245,6 +2245,7 @@ P.unitframe.units.arena.buffs.priority = 'Blacklist,TurtleBuffs,PlayerBuffs,Disp
 P.unitframe.units.arena.buffs.sizeOverride = 27
 P.unitframe.units.arena.buffs.yOffset = 16
 P.unitframe.units.arena.castbar.width = 256
+P.unitframe.units.arena.castbar.positionsGroup = { anchorPoint = 'BOTTOM', xOffset = 0, yOffset = 0}
 P.unitframe.units.arena.debuffs.enable = true
 P.unitframe.units.arena.debuffs.anchorPoint = 'LEFT'
 P.unitframe.units.arena.debuffs.maxDuration = 300

--- a/ElvUI_OptionsUI/UnitFrames.lua
+++ b/ElvUI_OptionsUI/UnitFrames.lua
@@ -374,7 +374,7 @@ local function GetOptionsTable_Castbar(updateFunc, groupName, numUnits)
 		config.args.displayTarget = ACH:Toggle(L["Display Target"], L["Display the target of current cast."], 13)
 	end
 
-	if groupName == 'party' then
+	if groupName == 'party' or groupName == 'arena' then
 		config.args.positionsGroup = ACH:Group(L["Position"], nil, 19, nil, function(info) return E.db.unitframe.units[groupName].castbar.positionsGroup[info[#info]] end, function(info, value) E.db.unitframe.units[groupName].castbar.positionsGroup[info[#info]] = value updateFunc(UF, groupName, numUnits) end)
 		config.args.positionsGroup.inline = true
 		config.args.positionsGroup.args.anchorPoint = ACH:Select(L["Position"], nil, 3, C.Values.AllPoints)


### PR DESCRIPTION
This pull request adds the previously missing options to configure the castbar positions for arena unit frames, in the same way it already works for party frames.

<img width="463" alt="image" src="https://user-images.githubusercontent.com/20967811/198252632-80a78c18-3a57-47bc-9d6a-6638bc0f2a12.png">
