### PR TITLE
Fix Masque skin masks not applying

### DIFF
--- a/ElvUI/Core/Modules/ActionBars/ActionBars.lua
+++ b/ElvUI/Core/Modules/ActionBars/ActionBars.lua
@@ -634,7 +634,7 @@ function AB:StyleButton(button, noBackdrop, useMasque, ignoreNormal)
 	if border and not button.useMasque then border:Kill() end
 	if action then action:SetAlpha(0) end
 	if slotbg then slotbg:Hide() end
-	if mask then mask:Hide() end
+	if mask and not button.useMasque then mask:Hide() end
 
 	if count then
 		local position, xOffset, yOffset = db and db.countTextPosition or 'BOTTOMRIGHT', db and db.countTextXOffset or 0, db and db.countTextYOffset or 2


### PR DESCRIPTION
We should allow Masque skins to apply their mask to the buttons so that unique shapes can still be achieved.