### PR TITLE
MacroFrame top tab text not vertically centered

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/Macro.lua
+++ b/ElvUI/Mainline/Modules/Skins/Macro.lua
@@ -44,6 +44,10 @@ function S:Blizzard_MacroUI()
 	_G.MacroFrameTab1:Point('TOPLEFT', MacroFrame, 'TOPLEFT', 12, -39)
 	_G.MacroFrameTab2:Point('LEFT', _G.MacroFrameTab1, 'RIGHT', 4, 0)
 
+	-- Reposition General / Character tab text to center
+	_G.MacroFrameTab1.Text:SetAllPoints(_G.MacroFrameTab1)
+	_G.MacroFrameTab2.Text:SetAllPoints(_G.MacroFrameTab2)
+
 	--Reposition edit button
 	_G.MacroEditButton:ClearAllPoints()
 	_G.MacroEditButton:Point('BOTTOMLEFT', _G.MacroFrameSelectedMacroButton, 'BOTTOMRIGHT', 10, 0)


### PR DESCRIPTION
Before 
<img width="369" alt="image" src="https://user-images.githubusercontent.com/778367/198896783-84cd0e7a-2862-4780-83f3-6e31a0e708f1.png">


After
<img width="374" alt="image" src="https://user-images.githubusercontent.com/778367/198896751-f79507e5-5557-44b6-a495-a814351262a3.png">