### PR TITLE
Add Evoker Cauterizing Flame dispel support

### DIFF
--- a/ElvUI_Libraries/Core/LibDispel/LibDispel.lua
+++ b/ElvUI_Libraries/Core/LibDispel/LibDispel.lua
@@ -97,9 +97,13 @@ do
 		elseif myClass == 'EVOKER' then
 			local naturalize = CheckSpell(360823) -- Naturalize (Preservation)
 			local expunge = CheckSpell(365585) -- Expunge (Devastation)
+			local cauterizing = CheckSpell(374251) -- Cauterizing Flame
 
 			DispelList.Magic = naturalize
-			DispelList.Poison = naturalize or expunge
+			DispelList.Poison = naturalize or expunge or cauterizing
+			DispelList.Disease = cauterizing
+			DispelList.Curse = cauterizing
+			-- todo add bleed dispel support for Cauterizing Flame
 		end
 
 		if undoRanks then


### PR DESCRIPTION
Evoker's Cauterizing Flame talent is a 1 minute CD that dispels Bleeds, Poisons, Curses, and Diseases. This change adds support for all of those effects except the Bleed dispel, since as far as I can tell, bleed dispels do not seem to be supported in this module yet.

Tested for disease dispel by taking the talent, being in a party, and getting a disease.