### PR TITLE
feat: add rating tooltip lines to crit and mastery

### DIFF
--- a/ElvUI/Core/Modules/DataTexts/Crit.lua
+++ b/ElvUI/Core/Modules/DataTexts/Crit.lua
@@ -1,16 +1,30 @@
 local E, L, V, P, G = unpack(ElvUI)
 local DT = E:GetModule('DataTexts')
 
+local _G = _G
+local format = format
 local strjoin = strjoin
-
 local GetCritChance = GetCritChance
 local GetRangedCritChance = GetRangedCritChance
+local GetCombatRating = GetCombatRating
+local GetCombatRatingBonus = GetCombatRatingBonus
+local BreakUpLargeNumbers = BreakUpLargeNumbers
 local STAT_CATEGORY_ENHANCEMENTS = STAT_CATEGORY_ENHANCEMENTS
+local STAT_CRITICAL_STRIKE = STAT_CRITICAL_STRIKE
 local CRIT_ABBR = CRIT_ABBR
 
 local displayString = ''
 local spellCrit, rangedCrit, meleeCrit = 0, 0, 0
 local critChance = 0
+
+local function OnEnter()
+	DT.tooltip:ClearLines()
+	local text = HIGHLIGHT_FONT_COLOR_CODE..format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAT_CRITICAL_STRIKE)..' '..format('%.2F%%', critChance)..FONT_COLOR_CODE_CLOSE
+	local classTooltip = _G['STAT_CRITICAL_STRIKE_'..E.myclass..'_TOOLTIP']
+	if not classTooltip then classTooltip = STAT_CRITICAL_STRIKE_TOOLTIP end
+	DT.tooltip:AddLine(format('%s: %s [+%.2f%%]', STAT_CRITICAL_STRIKE, BreakUpLargeNumbers(GetCombatRating(CR_HASTE_MELEE)), GetCombatRatingBonus(CR_HASTE_MELEE)))
+	DT.tooltip:Show()
+end
 
 local function OnEvent(self)
 	rangedCrit = GetRangedCritChance()
@@ -37,4 +51,4 @@ local function ValueColorUpdate(self, hex)
 	OnEvent(self)
 end
 
-DT:RegisterDatatext('Crit', STAT_CATEGORY_ENHANCEMENTS, { 'UNIT_STATS', 'UNIT_AURA', 'PLAYER_DAMAGE_DONE_MODS'}, OnEvent, nil, nil, nil, nil, _G.STAT_CRITICAL_STRIKE, nil, ValueColorUpdate)
+DT:RegisterDatatext('Crit', STAT_CATEGORY_ENHANCEMENTS, { 'UNIT_STATS', 'UNIT_AURA', 'PLAYER_DAMAGE_DONE_MODS'}, OnEvent, nil, nil, not E.Classic and OnEnter, nil, _G.STAT_CRITICAL_STRIKE, nil, ValueColorUpdate)

--- a/ElvUI/Mainline/Modules/DataTexts/Mastery.lua
+++ b/ElvUI/Mainline/Modules/DataTexts/Mastery.lua
@@ -7,6 +7,7 @@ local GetSpecialization = GetSpecialization
 local GetSpecializationMasterySpells = GetSpecializationMasterySpells
 local STAT_CATEGORY_ENHANCEMENTS = STAT_CATEGORY_ENHANCEMENTS
 local STAT_MASTERY = STAT_MASTERY
+local STAT_MASTERY_BASE_TOOLTIP = STAT_MASTERY_BASE_TOOLTIP
 local CreateBaseTooltipInfo = CreateBaseTooltipInfo
 
 local displayString = ''
@@ -37,6 +38,11 @@ local function OnEnter()
 				DT.tooltip:AddSpellByID(masterySpell2)
 			end
 		end
+		local mastery, bonusCoeff = GetMasteryEffect();
+		local masteryBonus = GetCombatRatingBonus(CR_MASTERY) * bonusCoeff;
+
+		DT.tooltip:AddLine(' ')
+		DT.tooltip:AddLine(format('%s: %s [+%.2f%%]', STAT_MASTERY, BreakUpLargeNumbers(GetCombatRating(CR_MASTERY)), masteryBonus))
 
 		DT.tooltip:Show()
 	end


### PR DESCRIPTION
Just adding this because I use a custom panel with all 4 of the secondary stat datatexts on it and crit didn't have a tooltip, and mastery never showed your rating. This was how i checked for ratings when comparing raw values between stats.

I couldn't find/figure out the class/base tooltip for crit, so I would appreciate some feedback on that if possible.