### PR TITLE
Tooltip.lua - same word different meaning

### DIFF
--- a/ElvUI/Core/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Core/Modules/Tooltip/Tooltip.lua
@@ -724,11 +724,11 @@ function TT:GameTooltip_OnTooltipSetItem(data)
 			local count = GetItemCount(link)
 			local total = GetItemCount(link, true)
 			if TT.db.itemCount == 'BAGS_ONLY' then
-				bagCount = format(IDLine, L["Count"], count)
+				bagCount = format(IDLine, L["Counts"], count)
 			elseif TT.db.itemCount == 'BANK_ONLY' then
 				bankCount = format(IDLine, L["Bank"], total - count)
 			elseif TT.db.itemCount == 'BOTH' then
-				bagCount = format(IDLine, L["Count"], count)
+				bagCount = format(IDLine, L["Counts"], count)
 				bankCount = format(IDLine, L["Bank"], total - count)
 			end
 		end


### PR DESCRIPTION
Bag's 'count' and Aura's 'count' are using the same word. A distinction needs to be made in localization.