### PR TITLE
Fix CharacterFrame/TokenFrame close buttons

### DIFF
--- a/ElvUI/Wrath/Modules/Skins/Character.lua
+++ b/ElvUI/Wrath/Modules/Skins/Character.lua
@@ -193,6 +193,9 @@ function S:CharacterFrame()
 
 	_G.PaperDollFrame:StripTextures()
 
+	_G.CharacterFrameCloseButton:SetNormalTexture(E.Media.Textures.Close)
+	_G.CharacterFrameCloseButton:GetNormalTexture():SetTexCoord(0, 1, 1, 1, 0, 0, 1, 0)
+
 	S:HandleRotateButton(_G.CharacterModelFrameRotateLeftButton)
 	_G.CharacterModelFrameRotateLeftButton:Point('TOPLEFT', 3, -3)
 	S:HandleRotateButton(_G.CharacterModelFrameRotateRightButton)

--- a/ElvUI/Wrath/Modules/Skins/Character.lua
+++ b/ElvUI/Wrath/Modules/Skins/Character.lua
@@ -557,7 +557,7 @@ function S:CharacterFrame()
 	_G.TokenFrameMoneyFrame:Kill()
 
 	for _, child in next, { _G.TokenFrame:GetChildren() } do
-		if not child:GetName() and strfind(child:GetNormalTexture():GetTexture(), 'MinimizeButton') then
+		if not child:GetName() then
 			child:Hide()
 			break
 		end


### PR DESCRIPTION
It seems that the CharacterFrameCloseButton texture gets stripped without setting it back again.
This resulted in a close button that still worked but was not visible on the top-right corner.

Additionally the TokenFrameCloseButton was still showing up on my client (without a skin even) which was caused by the texture name string compare not matching "MinimizeButton". I looked this button up inside the BlizzardInterfaceCode and it's the frame's only child element without a name so I removed this string compare alltogether.