### PR TITLE
fix the miscaculation of timer.endCooldown

### DIFF
--- a/ElvUI/Core/General/Cooldowns.lua
+++ b/ElvUI/Core/General/Cooldowns.lua
@@ -228,18 +228,19 @@ function E:OnSetCooldown(start, duration, modRate)
 		timer.duration = duration * (not timer.showModRate and modRate or 1)
 
 		local now = GetTime()
+		local cTime = time()
 		if start <= (now + 1) then -- this second is for Target Aura
 			timer.endTime = start + duration
+			timer.endCooldown = timer.endTime - now
 		else -- https://github.com/Stanzilla/WoWUIBugs/issues/47
-			local startup = time() - now
+			local startup = cTime - now
 			local cdtime = (2 ^ 32) / 1000 - start
 			local startTime = startup - cdtime
 			timer.endTime = startTime + duration
+			timer.endCooldown = timer.endTime - cTime
 		end
 
-		timer.endCooldown = timer.endTime - 0.05
 		timer.paused = nil -- a new cooldown was called
-
 		E:Cooldown_TimerUpdate(timer)
 	elseif self.timer then
 		E:Cooldown_TimerStop(self.timer)


### PR DESCRIPTION
I found the action bar with long hours cooldown would display wrong text.
But not always wrong though.
It starts with 12h down to 11h, 10h,then suddenly turn into 237d, 236d, etc
With debug output I notice timer.endCooldown value is completely wrong set.

I look into [https://github.com/Stanzilla/WoWUIBugs/issues/47](https://github.com/Stanzilla/WoWUIBugs/issues/47)
make some changes, and now can get the exact value compare to the tooltip info,
but I dont konw where to update the display text, 
it would be really helpful if someone could help update the cooldown text.
![caculate](https://github.com/tukui-org/ElvUI/assets/10347096/f6be9b32-03d6-4452-99e2-8455fc4458a4)
