### PR TITLE
Update Crests.lua

### DIFF
--- a/ElvUI/Mainline/Modules/DataTexts/Crests.lua
+++ b/ElvUI/Mainline/Modules/DataTexts/Crests.lua
@@ -40,7 +40,7 @@ local function GetCrestIcon(info)
 end
 
 local function GetCrestText(crest, info)
-	return format(crestText, crest.color, info.quantity, info.maxQuantity)
+	return format(crestText, crest.color, info.totalEarned, info.maxQuantity)
 end
 
 local function OnEvent(self)


### PR DESCRIPTION
Correcting an issue where the mouseover text showed "currently owned crests / seasonal maximum", instead of "total earned crests this season / seasonal maximum".

Fixes Issue #1117 