### PR TITLE
Fix issue with Tooltip not showing player names

### DIFF
--- a/ElvUI/Core/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Core/Modules/Tooltip/Tooltip.lua
@@ -230,7 +230,7 @@ function TT:SetUnitText(tt, unit, isPlayerUnit)
 
 		local nameColor = E:ClassColor(class) or PRIEST_COLOR
 
-		if TT.db.playerTitles and pvpName then
+		if TT.db.playerTitles and pvpName and pvpName ~= '' then
 			name = pvpName
 		end
 


### PR DESCRIPTION
This PR is fixing issue with #1155
**UnitPVPName** in some cases returns empty value instead of **nil**
