### PR TITLE
Retail: Fix Aura function name in EditorMode.

### DIFF
--- a/ElvUI/Core/Modules/Misc/EditorMode.lua
+++ b/ElvUI/Core/Modules/Misc/EditorMode.lua
@@ -133,7 +133,7 @@ function EM:Initialize()
 	-- account settings will be tainted
 	local mixin = _G.EditModeManagerFrame.AccountSettings
 	if CheckCastFrame() then mixin.RefreshCastBar = E.noop end
-	if CheckAuraFrame() then mixin.RefreshAuraFrame = E.noop end
+	if CheckAuraFrame() then mixin.RefreshBuffsAndDebuffs = E.noop end
 	if CheckBossFrame() then mixin.RefreshBossFrames = E.noop end
 	if CheckArenaFrame() then mixin.RefreshArenaFrames = E.noop end
 	if CheckRaidFrame() then mixin.RefreshRaidFrames = E.noop end


### PR DESCRIPTION
Swapped RefreshAuraFrame to RefreshBuffsAndDebuffs. Not sure if it was changed but RefreshAuraFrame is no longer in Blizzard code.