### PR TITLE
Update oUF_EnergyManaRegen.lua Mana Tick

### DIFF
--- a/ElvUI_Libraries/Core/oUF_Plugins/oUF_EnergyManaRegen.lua
+++ b/ElvUI_Libraries/Core/oUF_Plugins/oUF_EnergyManaRegen.lua
@@ -108,7 +108,7 @@ local OnUnitSpellcastSucceeded = function(_, _, _, _, spellID)
 	local spellCost = false
 	local costTable = GetSpellPowerCost(spellID)
 	for _, costInfo in next, costTable do
-		if costInfo.cost then
+		if costInfo.cost > 0 then
 			spellCost = true
 		end
 	end

--- a/ElvUI_Libraries/Core/oUF_Plugins/oUF_EnergyManaRegen.lua
+++ b/ElvUI_Libraries/Core/oUF_Plugins/oUF_EnergyManaRegen.lua
@@ -108,7 +108,7 @@ local OnUnitSpellcastSucceeded = function(_, _, _, _, spellID)
 	local spellCost = false
 	local costTable = GetSpellPowerCost(spellID)
 	for _, costInfo in next, costTable do
-		if costInfo.cost > 0 then
+		if costInfo.cost and costInfo.cost > 0 then
 			spellCost = true
 		end
 	end


### PR DESCRIPTION
Fixing bug where 0 cost abilities (like Wrath when empowered by Fury of Stormrage) would cause the 5 second rule visual ticker to reset after a cast instead of continuing to tick. 

https://github.com/tukui-org/ElvUI/issues/1146