### PR TITLE
Achievement Frame: Header Background Removal

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/Achievement.lua
+++ b/ElvUI/Mainline/Modules/Skins/Achievement.lua
@@ -177,6 +177,8 @@ function S:Blizzard_AchievementUI()
 	_G.AchievementFrameSummaryAchievementsHeaderHeader:SetVertexColor(1, 1, 1, .25)
 	_G.AchievementFrameSummaryCategoriesHeaderTexture:SetVertexColor(1, 1, 1, .25)
 	_G.AchievementFrameWaterMark:SetAlpha(0)
+	_G.AchievementFrameSummaryAchievementsHeaderHeader:SetAlpha(0)
+	_G.AchievementFrameSummaryCategoriesHeaderTexture:SetAlpha(0)
 
 	hooksecurefunc('AchievementFrameSummary_UpdateAchievements', function()
 		for i = 1, _G.ACHIEVEMENTUI_MAX_SUMMARY_ACHIEVEMENTS do


### PR DESCRIPTION
**Recent Achievements** & **Progress Overview** had a BG still present. This resolves that. Screenshots for better understanding.

**Before:**
![image](https://github.com/tukui-org/ElvUI/assets/95256492/7e7197b7-90f0-4e05-a4ef-de37e9eb64d7)

**After:**
![image](https://github.com/tukui-org/ElvUI/assets/95256492/6f5c0bbb-63c6-44a3-ab09-c5320c549aa2)
