### PR TITLE
Better way to handle Game menu frame

### DIFF
--- a/ElvUI/Core/General/API.lua
+++ b/ElvUI/Core/General/API.lua
@@ -853,7 +853,7 @@ function E:SetupGameMenu()
 	if E.Retail then
 		local button = CreateFrame('Button', 'ElvUI_GameMenuButton', GameMenuFrame, 'MainMenuFrameButtonTemplate')
 		button:SetScript('OnClick', E.ClickGameMenu)
-		button:Size(200, 35)
+		button:Size(150, 28)
 
 		GameMenuFrame.ElvUI = button
 		GameMenuFrame.MenuButtons = {}

--- a/ElvUI/Mainline/Modules/Skins/Misc.lua
+++ b/ElvUI/Mainline/Modules/Skins/Misc.lua
@@ -88,6 +88,7 @@ function S:BlizzardMiscFrames()
 
 			for button in menu.buttonPool:EnumerateActive() do
 				if not button.IsSkinned then
+					button:SetSize(150, 28)
 					S:HandleButton(button, nil, nil, nil, true)
 					button.backdrop:SetInside(nil, 1, 1)
 					hooksecurefunc(button, 'SetScript', ClearedHooks)


### PR DESCRIPTION
Instead of using scaling on game menu, maybe it's better to just change size of the buttons and let the Game menu frame adjust to the new button size.