### PR TITLE
Battlefield map improvements

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/BGMap.lua
+++ b/ElvUI/Mainline/Modules/Skins/BGMap.lua
@@ -42,11 +42,13 @@ local function OnMouseUp(_, btn)
 	end
 end
 
-local function OnMouseDown(_, btn)
+local function OnMouseDown(self, btn)
 	local tab = _G.BattlefieldMapTab
 	if btn == 'LeftButton' and (_G.BattlefieldMapOptions and not _G.BattlefieldMapOptions.locked) then
-		tab:SetUserPlaced(true)
-		tab:StartMoving()
+		if self == tab then
+			tab:SetUserPlaced(true)
+			tab:StartMoving()
+		end
 	end
 end
 

--- a/ElvUI/Mainline/Modules/Skins/BGMap.lua
+++ b/ElvUI/Mainline/Modules/Skins/BGMap.lua
@@ -45,6 +45,7 @@ end
 local function OnMouseDown(_, btn)
 	local tab = _G.BattlefieldMapTab
 	if btn == 'LeftButton' and (_G.BattlefieldMapOptions and not _G.BattlefieldMapOptions.locked) then
+		tab:SetUserPlaced(true)
 		tab:StartMoving()
 	end
 end

--- a/ElvUI/Mainline/Modules/Skins/BGMap.lua
+++ b/ElvUI/Mainline/Modules/Skins/BGMap.lua
@@ -11,6 +11,15 @@ local function SetBackdropAlpha()
 	end
 end
 
+local function SetScale()
+    _G.BattlefieldMapFrame.ScrollContainer:SetScale(1.0)
+end
+
+local function OnShow()
+    SetBackdropAlpha()
+    SetScale()
+end
+
 local function OnLeave()
 	_G.BattlefieldMapFrame.BorderFrame.CloseButton:SetAlpha(0.1)
 end
@@ -70,7 +79,7 @@ function S:Blizzard_BattlefieldMap()
 	S:HandleCloseButton(close)
 
 	hooksecurefunc(frame, 'SetGlobalAlpha', SetBackdropAlpha)
-	frame:HookScript('OnShow', SetBackdropAlpha)
+	frame:HookScript('OnShow', OnShow)
 
 	local scroll = frame.ScrollContainer
 	scroll:HookScript('OnMouseUp', OnMouseUp)


### PR DESCRIPTION
I've made a few improvements/fixes here:

1. Set a default scale level on the zone map, so that it's not giga-zoomed when you open it:
![zonemap-zoomed](https://github.com/user-attachments/assets/649fb908-6e0a-4d16-927f-c0b79e639b7e)

2. Mark that the frame has been moved by the player, so that its saved in the layout cache. This fixes this awkward position jumping that occurs:
https://imgur.com/a/9nLeP1d

3. Only allow the zone map to be moved using the tab. When you're zoomed in on the zone map, click-dragging is required in order to pan the map around. You cannot overlap functionality here, by attempting to allow the user to simultaneously move the frame. By doing so, you create this odd behavior where the map texture remains static as the scroll container moves over-top of it:
https://imgur.com/a/a3aprpW