### PR TITLE
Fixing reputation bar bug on WoW classic era

### DIFF
--- a/ElvUI/Core/Modules/DataBars/Reputation.lua
+++ b/ElvUI/Core/Modules/DataBars/Reputation.lua
@@ -63,7 +63,7 @@ function DB:ReputationBar_Update()
 		standing, currentReactionThreshold, nextReactionThreshold, currentStanding = info.reaction, info.reactionThreshold or 0, info.nextThreshold or huge, info.standing or 1
 	end
 
-	if E.Retail and not standing and factionID and C_Reputation_IsFactionParagon(factionID) then
+	if E.Retail and not standing and factionID and C_Reputation_IsFactionParagon and C_Reputation_IsFactionParagon(factionID) then
 		local current, threshold
 		current, threshold, _, rewardPending = C_Reputation_GetFactionParagonInfo(factionID)
 
@@ -152,7 +152,7 @@ function DB:ReputationBar_OnEnter()
 	local data = E:GetWatchedFactionInfo()
 	local name, reaction, currentReactionThreshold, nextReactionThreshold, currentStanding, factionID = data.name, data.reaction, data.currentReactionThreshold, data.nextReactionThreshold, data.currentStanding, data.factionID
 
-	local isParagon = E.Retail and factionID and C_Reputation_IsFactionParagon(factionID)
+	local isParagon = E.Retail and factionID and C_Reputation_IsFactionParagon and C_Reputation_IsFactionParagon(factionID)
 	local standing
 
 	if isParagon then


### PR DESCRIPTION
To reproduce the current bug - hover over the reputation bar. This will throw NPE as C_Reputation_IsFactionParagon is nil (presumably because Paragon isn't a thing in classic era).

The proposed simple fix appears to be sufficient.