### PR TITLE
Fix difficultycolor for units with a level of -1.

### DIFF
--- a/ElvUI/Core/General/Tags.lua
+++ b/ElvUI/Core/General/Tags.lua
@@ -574,7 +574,8 @@ E:AddTag('difficultycolor', 'UNIT_LEVEL PLAYER_LEVEL_UP', function(unit)
 			color = QuestDifficultyColors.difficult
 		end
 	else
-		color = GetCreatureDifficultyColor(UnitEffectiveLevel(unit))
+		local level = UnitEffectiveLevel(unit)
+		color = GetCreatureDifficultyColor((level > 0) and level or 999)
 	end
 
 	return Hex(color.r, color.g, color.b)


### PR DESCRIPTION
Since the inception of the `difficultycolor` tag, (yes i checked the git history) it has suffered from the issue of showing the grey trivial color for bosses, as their `UnitLevel` will return -1.

This change better matches oUF's `difficulty` tag.

Screenshot:
Top "??" uses `[difficulty][level]`, 
while lower uses `[difficultycolor][level]`
![2024 12 07 15 44 57 652](https://github.com/user-attachments/assets/f62922f1-433e-404b-9c71-76f0ac9b65e3)




<hr>

Seeing as this is how the tag has always displayed, and no one really noticed (myself included). I'd assume everyone is used to it being that color. Thoughts?
