### PR TITLE
make shaman blue in classic era

### DIFF
--- a/ElvUI/Core/General/API.lua
+++ b/ElvUI/Core/General/API.lua
@@ -194,7 +194,10 @@ end
 function E:ClassColor(class, usePriestColor)
 	if not class then return end
 
-	local color = (_G.CUSTOM_CLASS_COLORS and _G.CUSTOM_CLASS_COLORS[class]) or _G.RAID_CLASS_COLORS[class]
+	-- previously this grabbed directly from _G.CUSTOM_CLASS_COLORS but that already gets
+	-- iterated in colors.lua and writes the values to colors.class so it should be
+	-- safe to grab directly from colors instead?
+	local color = ElvUF.colors.class[class] or _G.RAID_CLASS_COLORS[class]
 	if type(color) ~= 'table' then return end
 
 	if not color.colorStr then

--- a/ElvUI_Libraries/Core/oUF/colors.lua
+++ b/ElvUI_Libraries/Core/oUF/colors.lua
@@ -109,6 +109,9 @@ local colors = {
 -- We do this because people edit the vars directly, and changing the default
 -- globals makes SPICE FLOW!
 local function customClassColors()
+	-- in classic era, shamans default to paladin pink. this forces it to blue.
+	colors.class["SHAMAN"] = oUF:CreateColor(0.0, 0.44, 0.87)
+
 	if(_G.CUSTOM_CLASS_COLORS) then
 		local function updateColors()
 			for classToken, color in next, _G.CUSTOM_CLASS_COLORS do


### PR DESCRIPTION
In classic era shaman health bars, chat names, cast bars, nameplates, etc all show up in paladin colors. This PR fixes that though I don't understand the codebase all that well so I'm more than happy to find a different way to do this if this method is not ideal.

Seems like having shaman as blue in classic era is a better default.

Before:
![image](https://github.com/user-attachments/assets/5fa4de49-314f-4080-ad93-483565aa50b4)

After:
![image](https://github.com/user-attachments/assets/18e37f56-b652-430b-9559-f4e3afb7cf66)
