### PR TITLE
Don't color chat tabs when chat module is disabled

### DIFF
--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -1444,6 +1444,9 @@ function CH:Panels_ColorUpdate()
 end
 
 function CH:UpdateChatTabColors()
+	-- don't proceed when chat is disabled
+	if not E.private.chat.enable then return end
+
 	for _, name in ipairs(_G.CHAT_FRAMES) do
 		local tab = CH:GetTab(_G[name])
 		CH:FCFTab_UpdateColors(tab, tab.selected)

--- a/ElvUI/Core/Modules/Chat/Chat.lua
+++ b/ElvUI/Core/Modules/Chat/Chat.lua
@@ -1420,7 +1420,7 @@ function CH:PositionChats()
 
 	LO:RepositionChatDataPanels()
 
-	-- dont proceed when chat is disabled
+	-- don't proceed when chat is disabled
 	if not E.private.chat.enable then return end
 
 	for _, name in ipairs(_G.CHAT_FRAMES) do


### PR DESCRIPTION
When the chat module is disabled, don't re-color the `ChatFrame` tabs.

There does not seem to be a Blizzard skin for the chat frames, so coupling this to the state of the chat module seems the best option.