### PR TITLE
fix SetupTooltip parameter for LDB plugins with custom tooltip

### DIFF
--- a/ElvUI/Core/Modules/DataTexts/DataTexts.lua
+++ b/ElvUI/Core/Modules/DataTexts/DataTexts.lua
@@ -218,7 +218,7 @@ function DT:BuildPanelFunctions(name, obj)
 	local function OnEnter(dt)
 		if obj.tooltip then
 			obj.tooltip:ClearAllPoints()
-			obj.tooltip:SetOwner(DT:SetupTooltip(self))
+			obj.tooltip:SetOwner(DT:SetupTooltip(dt))
 			obj.tooltip:Show()
 		else
 			DT.tooltip:ClearLines()


### PR DESCRIPTION
ElvUI triggers an error when hovering over a LDB plugin with a custom tooltip:

```
37x ...ceElvUI/Core/Modules/DataTexts/DataTexts.lua:334: attempt to call method 'GetParent' (a nil value)
[ElvUI/Core/Modules/DataTexts/DataTexts.lua]:334: in function <...ceElvUI/Core/Modules/DataTexts/DataTexts.lua:333>
[tail call]: ?
[ElvUI/Core/Modules/DataTexts/DataTexts.lua]:221: in function 'func'
[ElvUI/Core/Modules/DataTexts/DataTexts.lua]:101: in function <...ceElvUI/Core/Modules/DataTexts/DataTexts.lua:91>
[tail call]: ?
```

`SetupTooltip()` expects a frame, but `self` within `OnEnter` refers to `DT` - the DataTexts module itself.