### PR TITLE
Add "Count Text" and "Cooldown Text" options to the "Apply To All" Aura Indicator section

### DIFF
--- a/ElvUI_Options/Core/UnitFrames.lua
+++ b/ElvUI_Options/Core/UnitFrames.lua
@@ -303,6 +303,16 @@ local function GetOptionsTable_AuraWatch(updateFunc, groupName, numGroup, subGro
 		config.args.applyToAll.args.style = ACH:Select(L["Style"], nil, 2, { timerOnly = L["Timer Only"], coloredIcon = L["Colored Icon"], texturedIcon = L["Textured Icon"] })
 		config.args.applyToAll.args.textThreshold = ACH:Range(L["Text Threshold"], L["At what point should the text be displayed. Set to -1 to disable."], 3, { min = -1, max = 60, step = 1 })
 		config.args.applyToAll.args.displayText = ACH:Toggle(L["Display Text"], nil, 4)
+
+		config.args.applyToAll.args.countGroup = ACH:Group(L["Count Text"], nil, 20)
+		config.args.applyToAll.args.countGroup.args.countAnchor = ACH:Select(L["Anchor Point"], nil, 1, C.Values.AllPoints)
+		config.args.applyToAll.args.countGroup.args.countX = ACH:Range(L["X-Offset"], nil, 2, { min = -75, max = 75, step = 1 })
+		config.args.applyToAll.args.countGroup.args.countY = ACH:Range(L["Y-Offset"], nil, 3, { min = -75, max = 75, step = 1 })
+
+		config.args.applyToAll.args.cooldownGroup = ACH:Group(L["Cooldown Text"], nil, 25)
+		config.args.applyToAll.args.cooldownGroup.args.cooldownAnchor = ACH:Select(L["Anchor Point"], nil, 1, C.Values.AllPoints)
+		config.args.applyToAll.args.cooldownGroup.args.cooldownX = ACH:Range(L["X-Offset"], nil, 2, { min = -75, max = 75, step = 1 })
+		config.args.applyToAll.args.cooldownGroup.args.cooldownY = ACH:Range(L["Y-Offset"], nil, 3, { min = -75, max = 75, step = 1 })
 	end
 
 	return config


### PR DESCRIPTION
Setting the text positions for each aura indicator I'd like to be tracked on my unit frames is tiresome. Luckily, a base already exists for applying options to every aura.

Let's expand the "Apply To All" section on the "Aura Indicator" unitframe options to also include settings for the count text and the cooldown text. This makes it easier to adjust all the text positions inside the textured icon for all auras at once.

Tested with retail and ElvUI 13.87.