### PR TITLE
Parent chat bubble name to holder

### DIFF
--- a/ElvUI/Core/Modules/Misc/ChatBubbles.lua
+++ b/ElvUI/Core/Modules/Misc/ChatBubbles.lua
@@ -99,7 +99,7 @@ function M:SkinBubble(frame, holder)
 
 	if not frame.Name then
 		local name = holder:CreateFontString(nil, 'BORDER')
-		name:Height(10) --Width set in M:AddChatBubbleName()
+		name:Height(10) -- width set in M:AddChatBubbleName()
 		name:Point('BOTTOM', frame, 'TOP', 0, yOffset)
 		name:SetFontObject('ChatBubbleFont')
 		name:SetJustifyH('LEFT')

--- a/ElvUI/Core/Modules/Misc/ChatBubbles.lua
+++ b/ElvUI/Core/Modules/Misc/ChatBubbles.lua
@@ -98,7 +98,7 @@ function M:SkinBubble(frame, holder)
 	end
 
 	if not frame.Name then
-		local name = frame:CreateFontString(nil, 'BORDER')
+		local name = holder:CreateFontString(nil, 'BORDER')
 		name:Height(10) --Width set in M:AddChatBubbleName()
 		name:Point('BOTTOM', frame, 'TOP', 0, yOffset)
 		name:SetFontObject('ChatBubbleFont')


### PR DESCRIPTION
I use a few addons that hide certain NPC's chat bubbles. They seem to do the same thing of hiding the children of the chat bubble frame. But since the name text is parented to the frame and not the child frame, its not hidden. Leaving a floating name. 



