### PR TITLE
feat(crests): update id's for 11.2

### DIFF
--- a/ElvUI/Mainline/Modules/DataTexts/Crests.lua
+++ b/ElvUI/Mainline/Modules/DataTexts/Crests.lua
@@ -11,10 +11,10 @@ local CRESTS_EARNED = strsplit('%', _G.CURRENCY_SEASON_TOTAL_MAXIMUM)
 
 local crests = {
 	{ id = 3008, color = _G.HEIRLOOM_BLUE_COLOR:GenerateHexColor() },		-- Valorstones
-	{ id = 3107, color = _G.UNCOMMON_GREEN_COLOR:GenerateHexColor() },		-- Weathered
-	{ id = 3108, color = _G.RARE_BLUE_COLOR:GenerateHexColor() },			-- Carved
-	{ id = 3109, color = _G.EPIC_PURPLE_COLOR:GenerateHexColor() },			-- Runed
-	{ id = 3110, color = _G.LEGENDARY_ORANGE_COLOR:GenerateHexColor() }		-- Gilded
+	{ id = 3284, color = _G.UNCOMMON_GREEN_COLOR:GenerateHexColor() },		-- Weathered
+	{ id = 3286, color = _G.RARE_BLUE_COLOR:GenerateHexColor() },			-- Carved
+	{ id = 3289, color = _G.EPIC_PURPLE_COLOR:GenerateHexColor() },			-- Runed
+	{ id = 3290, color = _G.LEGENDARY_ORANGE_COLOR:GenerateHexColor() }		-- Gilded
 }
 
 local crestIcon = '|T%s:16:16:0:0:64:64:4:60:4:60|t'


### PR DESCRIPTION
This pull request updates the crest IDs in the `crests` table within `ElvUI/Mainline/Modules/DataTexts/Crests.lua` to reflect the latest game data. The new IDs replace the previous ones for Weathered, Carved, Runed, and Gilded crests.

Data update for crest definitions:

* Updated the `id` values for Weathered, Carved, Runed, and Gilded crests in the `crests` table to `3284`, `3286`, `3289`, and `3290` respectively, replacing the old IDs. (`[ElvUI/Mainline/Modules/DataTexts/Crests.luaL14-R17](diffhunk://#diff-d3bf2cbf35b3ac2560227ff008c099ec8439243a16ef68c16d5f23c3df878c92L14-R17)`)