### PR TITLE
feat: update the quest icon texture if needed for merchant item buttons

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/Merchant.lua
+++ b/ElvUI/Mainline/Modules/Skins/Merchant.lua
@@ -114,6 +114,16 @@ function S:MerchantFrame()
 		icon:Point('TOPLEFT', 1, -1)
 		icon:Point('BOTTOMRIGHT', -1, 1)
 
+		local questIcon = button.IconQuestTexture
+		questIcon:SetTexCoord(0, 1, 0, 1)
+		questIcon:SetInside()
+		local QuestIconSetTexture = questIcon.SetTexture
+		hooksecurefunc(questIcon, 'SetTexture', function(thisIcon, tex)
+			if tex == [[Interface\ContainerFrame\UI-Icon-QuestBang]] then
+				QuestIconSetTexture(thisIcon, E.Media.Textures.BagQuestIcon)
+			end
+		end)
+
 		S:HandleIconBorder(button.IconBorder)
 	end
 


### PR DESCRIPTION
before
<img width="594" height="419" alt="image" src="https://github.com/user-attachments/assets/f02f5df3-2012-46ff-b40c-a0d5976e70da" />


after
<img width="409" height="382" alt="image" src="https://github.com/user-attachments/assets/537988e9-b97e-4abd-8cbb-eebf907aedaa" />
