### PR TITLE
fix: fix the reposition of collection tab in timerunnig mode

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/Collectables.lua
+++ b/ElvUI/Mainline/Modules/Skins/Collectables.lua
@@ -750,7 +750,11 @@ local function HandleTabs()
 	-- Blizzard clears points on the wardrobe tab
 	hooksecurefunc('CollectionsJournal_CheckAndDisplayHeirloomsTab', function()
 		if _G.CollectionsJournalTab5 then
-			_G.CollectionsJournalTab5:Point('TOPLEFT', _G.CollectionsJournalTab4, 'TOPRIGHT', -5, 0)
+			local relativeTo = select(2, _G.CollectionsJournalTab5:GetPoint())
+			if relativeTo then
+				_G.CollectionsJournalTab5:ClearAllPoints()
+				_G.CollectionsJournalTab5:Point('TOPLEFT', relativeTo, 'TOPRIGHT', -5, 0)
+			end
 		end
 	end)
 end


### PR DESCRIPTION
before
<img width="413" height="49" alt="image" src="https://github.com/user-attachments/assets/781e0f39-04c5-4f09-ac49-ae67296905c4" />

after
<img width="378" height="76" alt="image" src="https://github.com/user-attachments/assets/89b6f1df-0a98-426a-890a-c9da4c41b0b2" />
