### PR TITLE
feat: update the default anchor index for new external event button

### DIFF
--- a/ElvUI/Core/General/API.lua
+++ b/ElvUI/Core/General/API.lua
@@ -1053,8 +1053,9 @@ function E:PLAYER_LEVEL_UP(_, level)
 end
 
 local gameMenuLastButtons = {
-	[_G.GAMEMENU_OPTIONS] = 1,
-	[_G.BLIZZARD_STORE] = 2
+	[_G.GAMEMENU_EXTERNALEVENT] = 1,
+	[_G.GAMEMENU_OPTIONS] = 2,
+	[_G.BLIZZARD_STORE] = 3
 }
 
 function E:PositionGameMenuButton()
@@ -1063,7 +1064,7 @@ function E:PositionGameMenuButton()
 			GameMenuFrame.Header.Text:SetTextColor(unpack(E.media.rgbvaluecolor))
 		end
 
-		local anchorIndex = (StoreEnabled and StoreEnabled() and 2) or 1
+		local anchorIndex = (StoreEnabled and StoreEnabled() and 3) or 2
 		for button in GameMenuFrame.buttonPool:EnumerateActive() do
 			local text = button:GetText()
 


### PR DESCRIPTION
## Description

Blizzard added a new button for opening the external URL, it already been used in China Mainland server.

## Preview

### Before

#### Original Blizzard UI

<img width="638" height="1002" alt="image" src="https://github.com/user-attachments/assets/751a41b3-0bae-42c8-8ae5-e6e4baff9130" />

#### ElvUI

<img width="481" height="917" alt="image" src="https://github.com/user-attachments/assets/51072bdd-7f43-4067-8165-faad70d4b725" />

### After

#### zhCN server (The event is on `C_ExternalEventURL.HasURL() => true`)

<img width="473" height="899" alt="image" src="https://github.com/user-attachments/assets/3bb76c67-e675-4d97-845a-dec5f042df70" />

#### zhTW server (the event is off, `C_ExternalEventURL.HasURL() => false`)

<img width="422" height="800" alt="image" src="https://github.com/user-attachments/assets/1b7c3a90-3bb0-46c7-b31b-1721f3895da8" />
