### PR TITLE
feat: add missing catalog shop skin

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/CatalogShop.lua
+++ b/ElvUI/Mainline/Modules/Skins/CatalogShop.lua
@@ -1,10 +1,15 @@
 local E, L, V, P, G = unpack(ElvUI)
 local S = E:GetModule('Skins')
+local TT = E:GetModule('Tooltip')
 
 local next = next
 
 function S:Blizzard_CatalogShop()
 	if not (E.private.skins.blizzard.enable and E.private.skins.blizzard.catalogShop) then return end
+
+	if E.private.skins.blizzard.tooltip and _G.CatalogShopTooltip then
+		TT:SetStyle(_G.CatalogShopTooltip)
+	end
 
 	local CatalogShopFrame = _G.CatalogShopFrame
 	if not CatalogShopFrame then


### PR DESCRIPTION
## Description 

Add 3 skins
- Back button
- The product details scroll bar
- Tooltip used in Catalog Shop

## Before

<img width="1837" height="1040" alt="image" src="https://github.com/user-attachments/assets/580ea68d-8aad-4d1d-9448-58d1b43ce7d2" />

## After

<img width="1886" height="985" alt="image" src="https://github.com/user-attachments/assets/59e068ef-1469-46f7-b892-8ac19e9a4b1b" />

