### PR TITLE
feat: add the disabled texture for max/min button

### DIFF
--- a/ElvUI/Core/Modules/Skins/Skins.lua
+++ b/ElvUI/Core/Modules/Skins/Skins.lua
@@ -1309,6 +1309,10 @@ do
 
 				button:SetPushedTexture(E.Media.Textures.ArrowUp)
 				button:GetPushedTexture():SetRotation(S.ArrowRotation[direction])
+
+				button:SetDisabledTexture(E.Media.Textures.ArrowUp)
+				button:GetDisabledTexture():SetRotation(S.ArrowRotation[direction])
+				button:GetDisabledTexture():SetVertexColor(.4, .4, .4)
 			end
 		end
 


### PR DESCRIPTION
# Description

Blizzard uses max/min button with disabled now. (top right)

## Before

<img width="860" height="441" alt="image" src="https://github.com/user-attachments/assets/c475b9db-a17a-498b-ba28-485895a7f306" />

## After

<img width="870" height="451" alt="image" src="https://github.com/user-attachments/assets/609a673d-ea9f-4525-8901-be5076436709" />
