### PR TITLE
fix: use field name to reskin

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/Friends.lua
+++ b/ElvUI/Mainline/Modules/Skins/Friends.lua
@@ -323,9 +323,8 @@ function S:FriendsFrame()
 		IgnoreWindow:SetTemplate('Transparent')
 		S:HandleTrimScrollBar(IgnoreWindow.ScrollBar)
 		S:HandleButton(IgnoreWindow.UnignorePlayerButton)
+		S:HandleCloseButton(IgnoreWindow.CloseButton)
 	end
-
-	S:HandleCloseButton(_G.FriendsFrameCloseButton) -- Probably missing/temp name
 
 	--Who Frame
 	_G.WhoFrame:StripTextures()


### PR DESCRIPTION
# before

<img width="334" height="332" alt="image" src="https://github.com/user-attachments/assets/bff66ef6-33c7-495a-a569-fd750397b78e" />


# after

<img width="328" height="327" alt="image" src="https://github.com/user-attachments/assets/aadde39e-1903-4062-8378-5353c23467ce" />

