### PR TITLE
feat: move the setting collapse button a little bit up

### DIFF
--- a/ElvUI/Mainline/Modules/Skins/SettingsPanel.lua
+++ b/ElvUI/Mainline/Modules/Skins/SettingsPanel.lua
@@ -118,7 +118,7 @@ local function CategoryListScrollUpdateChild(child)
 		if Toggle and not Toggle.IsSkinned then
 			S:HandleCollapseTexture(Toggle, true)
 			Toggle:Size(18)
-			Toggle:NudgePoint(4)
+			Toggle:NudgePoint(4, 2)
 			Toggle.IsSkinned = true
 		end
 


### PR DESCRIPTION
## Description

It seems the original text has offset on Y-axis, so move the button a little bit up.


## Before

<img width="203" height="28" alt="image" src="https://github.com/user-attachments/assets/5858360e-9db2-48db-a239-58b4fc2a537b" />


## After

<img width="213" height="39" alt="image" src="https://github.com/user-attachments/assets/dbd38b27-a3b2-4784-a0b3-804ab22f751d" />
