### PR TITLE
feat: add mover for housing controls

### DIFF
--- a/ElvUI/Game/Mainline/Modules/Skins/Housing.lua
+++ b/ElvUI/Game/Mainline/Modules/Skins/Housing.lua
@@ -315,6 +315,15 @@ function S:Blizzard_HousingModelPreview()
 	end
 end
 
+function S:Blizzard_HousingControls()
+	if not (E.private.skins.blizzard.enable and E.private.skins.blizzard.housing) then return end
+
+	local HousingControlsFrame = _G.HousingControlsFrame
+	if HousingControlsFrame then
+		E:CreateMover(HousingControlsFrame, 'HousingControlsFrameMover', L["Housing Controls Frame"], nil, nil, 'ALL,SOLO')
+	end
+end
+
 S:AddCallbackForAddon('Blizzard_HouseList')
 S:AddCallbackForAddon('Blizzard_HousingBulletinBoard')
 S:AddCallbackForAddon('Blizzard_HousingCornerstone')
@@ -324,3 +333,4 @@ S:AddCallbackForAddon('Blizzard_HousingHouseFinder')
 S:AddCallbackForAddon('Blizzard_HousingHouseSettings')
 S:AddCallbackForAddon('Blizzard_HouseEditor')
 S:AddCallbackForAddon('Blizzard_HousingModelPreview')
+S:AddCallbackForAddon('Blizzard_HousingControls')


### PR DESCRIPTION
## Description

It seems Blizzard not include the controls into Edit Mode, it can be handled by ElvUI Mover just like `MirrorTimers`.

<img width="428" height="120" alt="image" src="https://github.com/user-attachments/assets/54a4105d-1918-4e79-827f-a25e681040f9" />
