### PR TITLE
feat: add skin for tooltip compare header

### DIFF
--- a/ElvUI/Game/Mainline/Modules/Skins/Tooltip.lua
+++ b/ElvUI/Game/Mainline/Modules/Skins/Tooltip.lua
@@ -31,6 +31,13 @@ function S:StyleTooltips()
 		_G.SettingsTooltip,
 	} do
 		TT:SetStyle(tt)
+
+		local CompareHeader = tt.CompareHeader
+		if CompareHeader and not CompareHeader.IsSkinned then
+			CompareHeader:StripTextures()
+			CompareHeader:SetTemplate()
+			CompareHeader.IsSkinned = true
+		end
 	end
 end
 


### PR DESCRIPTION
## Before

<img width="260" height="107" alt="image" src="https://github.com/user-attachments/assets/9c76d177-bbb3-4f9a-a684-2b0dad00fd28" />


## After

<img width="572" height="140" alt="image" src="https://github.com/user-attachments/assets/191aac59-5e6f-4a26-a3a7-6145aec1fba2" />


## Blizzard Code

https://github.com/wind-addons/BlizzardInterfaceCode/blob/78ea983c9bf33892887261ebe363b3a16853a4ec/Interface/AddOns/Blizzard_GameTooltip/Mainline/GameTooltip.xml#L111