### PR TITLE
fix(Wrath): Kill TemporaryEnchantFrame in Auras module to prevent duplicate display

### DIFF
--- a/ElvUI/Game/Shared/Modules/Auras/Auras.lua
+++ b/ElvUI/Game/Shared/Modules/Auras/Auras.lua
@@ -607,7 +607,7 @@ function A:Initialize()
 			_G.DebuffFrame:Kill()
 		end
 
-		if E.Mists or E.Classic then
+		if E.Wrath or E.Mists or E.Classic then
 			_G.TemporaryEnchantFrame:Kill()
 		end
 


### PR DESCRIPTION
### Description
This PR fixes a specific issue observed on the **Titan server** where the default Blizzard `TemporaryEnchantFrame` was not being properly removed. This resulted in temporary weapon enchants (such as Warlock Spellstones) appearing in the default Blizzard position/style, creating a duplicate display alongside ElvUI.

### The Fix
Modified `ElvUI/Game/Shared/Modules/Auras/Auras.lua`.
Included the necessary check to ensure the `TemporaryEnchantFrame` is correctly killed in this environment.

**Code Change:**
```lua
-- Before
if E.Mists or E.Classic then
    _G.TemporaryEnchantFrame:Kill()
end

-- After
if E.Wrath or E.Mists or E.Classic then
    _G.TemporaryEnchantFrame:Kill()
end
```

### Screenshot
#### Before
<img width="689" height="431" alt="image" src="https://github.com/user-attachments/assets/df129f0d-1768-45dc-976d-86a0e6ad97f7" />

#### After
<img width="729" height="489" alt="image" src="https://github.com/user-attachments/assets/88c3d676-4313-42e2-bd16-40f8c2c87df2" />
