### PR TITLE
feat: add all points support for cooldown text

### DIFF
--- a/ElvUI/Game/Shared/General/Cooldowns.lua
+++ b/ElvUI/Game/Shared/General/Cooldowns.lua
@@ -43,6 +43,10 @@ function E:CooldownTextures(cooldown, texture, edge, swipe)
 	cooldown:SetSwipeTexture(E.media.blankTex, swipe.r, swipe.g, swipe.b, swipe.a)
 end
 
+local function GetTextJustify(anchor)
+	return (anchor == 'TOPLEFT' or anchor == 'BOTTOMLEFT' or anchor == 'LEFT') and 'LEFT' or (anchor == 'TOPRIGHT' or anchor == 'BOTTOMRIGHT' or anchor == 'RIGHT') and 'RIGHT' or 'CENTER'
+end
+
 function E:CooldownText(cooldown, db, data, hide)
 	if not cooldown then return end
 
@@ -60,7 +64,8 @@ function E:CooldownText(cooldown, db, data, hide)
 
 		text:ClearAllPoints()
 		text:SetTextColor(colors.r, colors.g, colors.b)
-		text:Point('CENTER', nil, db.position, db.offsetX, db.offsetY)
+		text:Point(db.position, db.offsetX, db.offsetY)
+		text:SetJustifyH(GetTextJustify(db.position))
 		text:FontTemplate(LSM:Fetch('font', db.font), db.fontSize, db.fontOutline)
 	end
 end

--- a/ElvUI_Options/Game/Shared/Cooldown.lua
+++ b/ElvUI_Options/Game/Shared/Cooldown.lua
@@ -56,7 +56,7 @@ local function Group(order, db, label)
 	mainArgs.fontGroup = fonts
 
 	local position = ACH:Group(L["Text Position"], nil, 50)
-	position.args.position = ACH:Select(L["Position"], nil, 1, C.Values.AllPositions)
+	position.args.position = ACH:Select(L["Position"], nil, 1, C.Values.AllPoints)
 	position.args.offsetX = ACH:Range(L["X-Offset"], nil, 2, { min = -50, max = 50, step = 1 })
 	position.args.offsetY = ACH:Range(L["Y-Offset"], nil, 3, { min = -50, max = 50, step = 1 })
 	position.inline = true


### PR DESCRIPTION
## Summary

1. Expand cd text position option to all points.
2. Update the cd text position logic.
     - I have considered about retains old behavior, but set same `relativePoint` and `anchorPoint` seems more general in other addons.
     - The breaking change may affects user current setting:
       - `"CENTER", nil, "TOP", x, y` -> `"TOP", x, y`
4. Add justifyH tweak for different position.

## Before

https://github.com/user-attachments/assets/2e6a1375-7408-43d8-bd39-50fb24492dba

## After

https://github.com/user-attachments/assets/21d9e3d0-5ee3-441d-9f88-f8f56821c47c


