### PR TITLE
fix: re-show objective tracker when hidden

### DIFF
--- a/ElvUI/Game/Shared/Modules/Blizzard/Blizzard.lua
+++ b/ElvUI/Game/Shared/Modules/Blizzard/Blizzard.lua
@@ -132,6 +132,7 @@ end
 
 function BL:ObjectiveTracker_Expand(frame)
 	frame:SetParent(_G.UIParent)
+	if not frame:IsShown() then frame:Show() end
 end
 
 function BL:ObjectiveTracker_AutoHideOnShow()


### PR DESCRIPTION
When using AutoHide for boss fights, the objective tracker is sometimes being actually hidden, not just re-parented. When this happens, moving it back to the UIParent doesn't make it show again on its own. This fix explicitly calls Show to restore it.

To reproduce this issue engage a boss and observe that after the fight the objective frame doesn't come back.

The attached screenshot shows the debug status as well as some logging I added before and after the SetParent calls in the Collapse and Expand methods: ![WoWScrnShot_032826_105446](https://github.com/user-attachments/assets/1c8acedc-ab28-4fae-a81f-d5f2800840a1)

You can see that during the call to `BL:ObjectiveTracker_Collapse`, both before and after the call to re-parent the frame, the `IsShown()` API call returns `true` as expected. However, after the fight, when the `AutoHider`'s state changes and its OnShow method eventually calls `ObjectiveTracker_Expand`, `IsShown()` now returns `false`. Because of that, even after you move it to the parent, `IsVisible()` is still also `false` and the frame doesn't show back up.

Ideally it would be nice to track down what is actually causing IsShown to return `false` on the frame and prevent it, but I can't find it anywhere. I'm hoping this workaround is good enough for now, or that my debugging provides some insight into how to better address the issue to someone more knowledgeable about it.