### PR TITLE
Fix MoneyFrame_Update taint crash from tooltip font modifications

### DIFF
--- a/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
@@ -1088,13 +1088,16 @@ function TT:SetTooltipFonts()
 	local font, fontSize, fontOutline = LSM:Fetch('font', TT.db.font), TT.db.textFontSize, TT.db.fontOutline
 	_G.GameTooltipText:FontTemplate(font, fontSize, fontOutline)
 
-	if GameTooltip.hasMoney then
+	if GameTooltip.hasMoney and not E.Retail then -- Retail uses moneyLines; modifying MoneyFrame fonts taints buttons and crashes MoneyFrame_Update
 		for i = 1, GameTooltip.numMoneyFrames do
-			_G['GameTooltipMoneyFrame'..i..'PrefixText']:FontTemplate(font, fontSize, fontOutline)
-			_G['GameTooltipMoneyFrame'..i..'SuffixText']:FontTemplate(font, fontSize, fontOutline)
-			_G['GameTooltipMoneyFrame'..i..'GoldButtonText']:FontTemplate(font, fontSize, fontOutline)
-			_G['GameTooltipMoneyFrame'..i..'SilverButtonText']:FontTemplate(font, fontSize, fontOutline)
-			_G['GameTooltipMoneyFrame'..i..'CopperButtonText']:FontTemplate(font, fontSize, fontOutline)
+			local moneyFrame = _G['GameTooltipMoneyFrame'..i]
+			if moneyFrame and E:NotSecretValue(moneyFrame:GetWidth()) then
+				_G['GameTooltipMoneyFrame'..i..'PrefixText']:FontTemplate(font, fontSize, fontOutline)
+				_G['GameTooltipMoneyFrame'..i..'SuffixText']:FontTemplate(font, fontSize, fontOutline)
+				_G['GameTooltipMoneyFrame'..i..'GoldButtonText']:FontTemplate(font, fontSize, fontOutline)
+				_G['GameTooltipMoneyFrame'..i..'SilverButtonText']:FontTemplate(font, fontSize, fontOutline)
+				_G['GameTooltipMoneyFrame'..i..'CopperButtonText']:FontTemplate(font, fontSize, fontOutline)
+			end
 		end
 	end
 


### PR DESCRIPTION
## Problem
On Retail, hovering world quest POIs (and other tooltip triggers that display gold amounts) causes a Lua error:
MoneyFrame.lua:307: attempt to perform arithmetic on a secret number value
(execution tainted by 'ElvUI')

**Stack trace:** `TaskPOI_OnEnter` → `GameTooltip_AddQuest` → `GameTooltip_AddQuestRewardsToTooltip` → `SetTooltipMoney` → `MoneyFrame_Update` → crash

## Root Cause
In `SetTooltipFonts()` (Tooltip.lua, line 1091–1098), ElvUI calls `FontTemplate()` on the `GameTooltipMoneyFrame` button text elements (GoldButtonText, SilverButtonText, CopperButtonText). This taints those button frames. When Blizzard's `MoneyFrame_Update` later runs and calls `:GetWidth()` on the buttons to calculate layout, the return values are "secret" (tainted) numbers. The arithmetic `width = width + goldButton:GetWidth()` at line 307 then crashes because WoW prohibits arithmetic on secret values.

## Fix
Two changes in `SetTooltipFonts()`:

- **Skip MoneyFrame font modifications entirely on Retail** (`not E.Retail`). On Retail, ElvUI already has its own money line rendering via `AddLinePreCall(LINETYPE_SELLPRICE, TT.AddMoneyInfo)` (the `moneyLines` option, enabled by default). Modifying the Blizzard MoneyFrame fonts is unnecessary and actively harmful.
- **Add `NotSecretValue` guard for Classic variants** where `moneyLines` is not available. This prevents the font modifications when the MoneyFrame is already in a tainted state, matching the existing pattern used in `SetStyle()` (line 900).

## Testing
- Hover world quest POIs on the world map → no Lua error
- Hover items with sell prices in bags → moneyLines displays correctly
- Loot mobs with gold drops → no Lua error
- Classic/TBC/Wrath: MoneyFrame fonts still apply when not tainted

## File Changed
`ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua`

## Related Issues
- wind-addons/ElvUI_WindTools#626
- wind-addons/ElvUI_WindTools#627
- ATTWoWAddon/AllTheThings#2265
- kemayo/wow-handynotes-warwithin#24
- kemayo/wow-handynotes-dragonflight#42