### PR TITLE
Fix: CastingBarFrame taint and AuraHighlight script execution timeout

### DIFF
--- a/ElvUI_Libraries/Game/Shared/oUF/blizzard.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF/blizzard.lua
@@ -88,7 +88,13 @@ local function handleFrame(baseName, doNotReparent, isNamePlate)
 
 		local castbar = frame.castBar or frame.spellbar or frame.CastingBarFrame
 		if(castbar) then
-			castbar:UnregisterAllEvents()
+			-- Prevent CastingBarFrame taint by disconnecting unit instead of unregistering events
+			if(castbar == _G.CastingBarFrame) then
+				castbar:SetUnit(nil)
+				castbar:SetAlpha(0)
+			else
+				castbar:UnregisterAllEvents()
+			end
 		end
 
 		local altpowerbar = frame.powerBarAlt or frame.PowerBarAlt

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
@@ -46,9 +46,13 @@ end
 local function Looper(unit, filter, check, list, func)
 	local unitAuraFiltered = AuraFiltered[filter][unit]
 	local auraInstanceID, aura = next(unitAuraFiltered)
+	local count = 0
 	while aura do
-		local name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID = oUF:UnpackAuraData(aura)
-		local AuraType, Icon, filtered, style, color = func(aura, check, list, name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID)
+		count = count + 1
+		if count > 40 then break end -- Safety break to prevent 'script ran too long' errors
+
+		local name, icon, countAura, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID = oUF:UnpackAuraData(aura)
+		local AuraType, Icon, filtered, style, color = func(aura, check, list, name, icon, countAura, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID)
 
 		if Icon then
 			return aura, AuraType, Icon, filtered, style, color


### PR DESCRIPTION
This Pull Request addresses two critical stability issues identified in version 15.13:

1. **CastingBarFrame Taint**: Replaced `UnregisterAllEvents()` with `SetUnit(nil)` and `SetAlpha(0)` for the default Blizzard CastingBarFrame. This prevents the UI taint that causes `StopFinishAnims` to fail when Blizzard's secure code attempts to iterate over animation tables during combat.

2. **AuraHighlight Performance**: Added a safety limit to the `Looper` function in `oUF_AuraHighlight.lua`. By breaking the loop after 40 iterations, we prevent the "script ran too long" errors that frequently occur in high-density aura environments like raids.

These changes ensure smoother performance and fewer UI interruptions during intense combat encounters.