### PR TITLE
Fix: private auras get stuck on wrong frame after roster changes

### DIFF
--- a/ElvUI/Game/Shared/Modules/Misc/PrivateAuras.lua
+++ b/ElvUI/Game/Shared/Modules/Misc/PrivateAuras.lua
@@ -184,18 +184,18 @@ function PA:CreateAura(parent, unit, index, db)
 
 	aura:ClearAllPoints()
 
-	local step = db.icon.size + (db.icon.offset or 0)
+	local point, step = db.icon.point, db.icon.size + (db.icon.offset or 0)
 	local compensate = (db.clickThrough and db.icon.size * 0.5) or 0
-	local x, y = 0, 0
+	local previous, x, y = index - 1, 0, 0
 
-	if db.icon.point == 'RIGHT' then
-		x = (index - 1) * step + compensate
-	elseif db.icon.point == 'LEFT' then
-		x = -(index - 1) * step - compensate
-	elseif db.icon.point == 'TOP' then
-		y = (index - 1) * step + compensate
-	elseif db.icon.point == 'BOTTOM' then
-		y = -(index - 1) * step - compensate
+	if point == 'RIGHT' then
+		x = previous * step + compensate
+	elseif point == 'LEFT' then
+		x = -previous * step - compensate
+	elseif point == 'TOP' then
+		y = previous * step + compensate
+	else -- bottom
+		y = -previous * step - compensate
 	end
 
 	aura:Point('CENTER', parent, x, y)

--- a/ElvUI/Game/Shared/Modules/Misc/PrivateAuras.lua
+++ b/ElvUI/Game/Shared/Modules/Misc/PrivateAuras.lua
@@ -184,23 +184,21 @@ function PA:CreateAura(parent, unit, index, db)
 
 	aura:ClearAllPoints()
 
-	local offsetNoMouse = (db.clickThrough and db.icon.size) or 0
-	if index == 1 then
-		aura:Point('CENTER', parent, -(offsetNoMouse * 0.5), 0)
-	else
-		local offsetX, offsetY, offsetIcon = 0, 0, db.icon.offset + offsetNoMouse
-		if db.icon.point == 'RIGHT' then
-			offsetX = offsetIcon
-		elseif db.icon.point == 'LEFT' then
-			offsetX = -offsetIcon
-		elseif db.icon.point == 'TOP' then
-			offsetY = offsetIcon
-		else
-			offsetY = -offsetIcon
-		end
+	local step = db.icon.size + (db.icon.offset or 0)
+	local compensate = (db.clickThrough and db.icon.size * 0.5) or 0
+	local x, y = 0, 0
 
-		aura:Point(E.InversePoints[db.icon.point], parent.auraIcons[index-1], db.icon.point, offsetX, offsetY)
+	if db.icon.point == 'RIGHT' then
+		x = (index - 1) * step + compensate
+	elseif db.icon.point == 'LEFT' then
+		x = -(index - 1) * step - compensate
+	elseif db.icon.point == 'TOP' then
+		y = (index - 1) * step + compensate
+	elseif db.icon.point == 'BOTTOM' then
+		y = -(index - 1) * step - compensate
 	end
+
+	aura:Point('CENTER', parent, x, y)
 
 	return aura
 end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -2199,10 +2199,10 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-       if self.PrivateAuras and (event == 'PLAYER_ENTERING_WORLD' or event == 'GROUP_ROSTER_UPDATE') then
-           UF:Configure_PrivateAuras(self)
-       end
-   end
+	if self.PrivateAuras and (event == 'PLAYER_ENTERING_WORLD' or event == 'GROUP_ROSTER_UPDATE') then
+		UF:Configure_PrivateAuras(self)
+	end
+end
 
 function UF:AfterStyleCallback()
 	-- this will wait until after ouf pushes `EnableElement` onto the newly spawned frames

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -2199,7 +2199,7 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-	if self.PrivateAuras and (event == 'PLAYER_ENTERING_WORLD' or event == 'GROUP_ROSTER_UPDATE') then
+	if self.PrivateAuras and (event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD') then
 		UF:Configure_PrivateAuras(self)
 	end
 end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -2199,12 +2199,7 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-       if self.PrivateAuras and (
-           event == 'OnShow'
-           or event == 'PLAYER_ENTERING_WORLD'
-           or event == 'GROUP_ROSTER_UPDATE'
-           or event == 'PLAYER_REGEN_ENABLED'
-       ) then
+       if self.PrivateAuras and (event == 'PLAYER_ENTERING_WORLD' or event == 'GROUP_ROSTER_UPDATE') then
            UF:Configure_PrivateAuras(self)
        end
    end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -2199,10 +2199,15 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-	if self.PrivateAuras and (event == 'OnShow' or event == 'PLAYER_ENTERING_WORLD') then
-		UF:Configure_PrivateAuras(self)
-	end
-end
+       if self.PrivateAuras and (
+           event == 'OnShow'
+           or event == 'PLAYER_ENTERING_WORLD'
+           or event == 'GROUP_ROSTER_UPDATE'
+           or event == 'PLAYER_REGEN_ENABLED'
+       ) then
+           UF:Configure_PrivateAuras(self)
+       end
+   end
 
 function UF:AfterStyleCallback()
 	-- this will wait until after ouf pushes `EnableElement` onto the newly spawned frames


### PR DESCRIPTION
## Problem

   Private aura icons on party/raid frames sometimes appear on the wrong
   unit after roster changes (members joining/leaving, role swaps), or
   fail to appear at all on affected players. A `/reload` fixes it
   temporarily but the issue returns at the next roster change.

   ## Root cause

   `UF:Configure_PrivateAuras(frame)` is only re-invoked via
   `UF:UpdateAllElements(event)` when the event is `OnShow` or
   `PLAYER_ENTERING_WORLD`. Neither fires when `SecureGroupHeader`
   reassigns a visible frame's unit token (e.g. `party3` → `party1`
   after someone leaves). The private aura anchor stays bound to the
   old unit token, so the icon shows on the wrong target until reload.

   ## Fix

   Add `GROUP_ROSTER_UPDATE` and `PLAYER_REGEN_ENABLED` to the events
   that trigger `Configure_PrivateAuras`. `PA:RemoveAuras` and
   `PA:SetupAuras` already handle clean teardown and rebuild, so no
   new infrastructure is needed.

   `PLAYER_REGEN_ENABLED` catches the case where a roster change
   happened mid-combat and was deferred by combat lockdown.