### PR TITLE
fix: guard secret unit frame values

### DIFF
--- a/ElvUI/Game/Shared/General/Animation.lua
+++ b/ElvUI/Game/Shared/General/Animation.lua
@@ -411,6 +411,7 @@ end
 -- Convenience function to do a simple fade out
 function E:UIFrameFadeOut(frame, timeToFade, startAlpha, endAlpha)
 	if not frame or frame:IsForbidden() then return end
+	if E:IsSecretValue(startAlpha) then return end
 
 	if frame.FadeObject then
 		frame.FadeObject.fadeTimer = nil

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua
@@ -26,6 +26,8 @@ local list = {}
 UF.RangeSpells = list
 
 function UF:UpdateRangeList(db)
+	if not db then return {} end
+
 	local spells = {}
 	for spell, value in next, db do
 		if value then
@@ -78,6 +80,8 @@ end
 
 function UF:UnitInSpellsRange(unit, which)
 	local spells = list[which]
+	if not spells then return nil end
+
 	local range = (not next(spells) and 1) or UF:UnitSpellRange(unit, spells)
 
 	if (not range or range == 1) and not InCombatLockdown() then

--- a/ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua
@@ -42,9 +42,41 @@ local oUF = ns.oUF
 local UnitGUID = UnitGUID
 local UnitClass = UnitClass
 local UnitIsVisible = UnitIsVisible
+local UnitIsPlayer = UnitIsPlayer
 local UnitIsConnected = UnitIsConnected
 local SetPortraitTexture = SetPortraitTexture
+local C_Timer = C_Timer
 local IsUnitModelReadyForUI = IsUnitModelReadyForUI
+
+local function HidePortraitFallback(element)
+	if element.Fallback2D then
+		element.Fallback2D:Hide()
+	end
+
+	element.secretRetryUnit = nil
+	element.secretRetryCount = nil
+end
+
+local function RetrySecretPortrait(element, unit)
+	if not C_Timer then return end
+	if element.secretRetryUnit == unit then return end
+
+	element.secretRetryUnit = unit
+	element.secretRetryCount = 0
+
+	local function retry()
+		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
+
+		element.secretRetryCount = (element.secretRetryCount or 0) + 1
+		element:SetUnit(unit)
+
+		if element.secretRetryCount < 4 then
+			C_Timer.After(0.2 * element.secretRetryCount, retry)
+		end
+	end
+
+	C_Timer.After(0.1, retry)
+end
 
 local function Update(self, event)
 	local element = self.Portrait
@@ -55,10 +87,14 @@ local function Update(self, event)
 
 	local guid = UnitGUID(unit)
 	local secretGUID = oUF:IsSecretValue(guid)
-	local newGUID = secretGUID or (element.guid ~= guid)
+	local storedGUID = element.guid
+	local secretStoredGUID = oUF:IsSecretValue(storedGUID)
+	local newGUID = secretGUID or secretStoredGUID or (storedGUID ~= guid)
 
 	local nameplate = event == 'NAME_PLATE_UNIT_ADDED'
 	if newGUID then
+		element.secretRetryUnit = nil
+		element.secretRetryCount = nil
 		element.guid = not secretGUID and guid or nil
 	elseif nameplate then
 		return
@@ -72,21 +108,73 @@ local function Update(self, event)
 	--]]
 	if(element.PreUpdate) then element:PreUpdate(unit) end
 
-	local isAvailable = element:IsVisible() and IsUnitModelReadyForUI(unit) and UnitIsConnected(unit) and UnitIsVisible(unit)
+	-- In Midnight, UnitIsPlayer returns a secret boolean for instanced NPCs.
+	-- A secret boolean is truthy in Lua, so `not secretFalse == false`, which
+	-- incorrectly treats NPCs as players and forces IsUnitModelReadyForUI checks.
+	local isPlayerRaw = UnitIsPlayer(unit)
+	local isPlayer = (isPlayerRaw == true)
+	local isSecret = oUF:IsSecretValue(isPlayerRaw)
+	local isVisible = not isPlayer or UnitIsVisible(unit)
+	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (IsUnitModelReadyForUI(unit) and UnitIsConnected(unit)))
 	local hasStateChanged = newGUID or (not nameplate or element.state ~= isAvailable)
 	if hasStateChanged then
 		element.playerModel = element:IsObjectType('PlayerModel')
+		local prevState = element.state
 		element.state = isAvailable
 
 		if element.playerModel then
-			element:ClearModel()
-			element:SetCamDistanceScale(isAvailable and 1 or 0.25)
-			element:SetPortraitZoom(isAvailable and 1 or 0)
-			element:SetPosition(0, 0, isAvailable and 0 or 0.25)
+			if not element.modelLoadedHooked then
+				element.modelLoadedHooked = true
+				pcall(element.HookScript, element, "OnModelLoaded", HidePortraitFallback)
+			end
 
 			if isAvailable then
-				element:SetUnit(unit)
+				if element.Fallback2D and not secretGUID then
+					HidePortraitFallback(element)
+				end
+
+				element:SetCamDistanceScale(1)
+				element:SetPortraitZoom(1)
+				element:SetPosition(0, 0, 0)
+				-- For secret GUIDs (dungeon/raid units in Midnight), newGUID is always true.
+				-- These events fire repeatedly without a genuine unit change (streaming, party status,
+				-- connection state) and would abort async model loading if they triggered SetUnit.
+				-- OnShow is added explicitly: when a frame re-appears (new pull, pet revival) with
+				-- the same GUID, the engine may have cleared the model while the frame was hidden.
+				-- UNIT_MODEL_CHANGED in Midnight fires when SetUnit starts streaming, not only on
+				-- genuine model changes. Allowing it for secret GUIDs causes SetUnit→event→SetUnit loops.
+				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
+				local needsLoad = (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				if needsLoad then
+					if secretGUID then
+						element:ClearModel()
+
+						if not element.Fallback2D then
+							local fallback = element:CreateTexture(nil, "BACKGROUND")
+							fallback:SetAllPoints(element)
+							fallback:SetTexCoord(0.15, 0.85, 0.15, 0.85)
+							element.Fallback2D = fallback
+						else
+							element.Fallback2D:SetDrawLayer("BACKGROUND")
+						end
+
+						SetPortraitTexture(element.Fallback2D, unit)
+						element.Fallback2D:Show()
+					end
+
+					element:SetUnit(unit)
+
+					if secretGUID then
+						RetrySecretPortrait(element, unit)
+					end
+				end
 			else
+				HidePortraitFallback(element)
+
+				element:ClearModel()
+				element:SetCamDistanceScale(0.25)
+				element:SetPortraitZoom(0)
+				element:SetPosition(0, 0, 0.25)
 				element:SetModel([[Interface\Buttons\TalkToMeQuestionMark.m2]])
 			end
 		elseif element.useClassBase then
@@ -138,6 +226,7 @@ local function Enable(self, unit)
 		local playerModel = element:IsObjectType('PlayerModel')
 		if playerModel then
 			self:RegisterEvent('UNIT_MODEL_CHANGED', Path)
+			self:RegisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 		else
 			self:RegisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 			self:RegisterEvent('PORTRAITS_UPDATED', Path, true)
@@ -165,9 +254,12 @@ local function Disable(self)
 
 		local playerModel = element:IsObjectType('PlayerModel')
 		if playerModel then
+			HidePortraitFallback(element)
+
 			element:ClearModel()
 
 			self:UnregisterEvent('UNIT_MODEL_CHANGED', Path)
+			self:UnregisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 		else
 			self:UnregisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 			self:UnregisterEvent('PORTRAITS_UPDATED', Path)

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
@@ -12,7 +12,10 @@ local UnitCanAssist = UnitCanAssist
 
 local function DebuffLoop(_, check, list, name, icon, _, auraType, _, _, _, _, _, spellID)
 	local allowSpell = oUF:NotSecretValue(spellID)
-	local spell = list and (allowSpell and oUF:NotSecretValue(name)) and (list[spellID] or list[name])
+	local spell
+	if list and allowSpell and oUF:NotSecretValue(name) then
+		spell = list[spellID] or list[name]
+	end
 
 	if spell then
 		if spell.enable then
@@ -31,7 +34,10 @@ local function DebuffLoop(_, check, list, name, icon, _, auraType, _, _, _, _, _
 end
 
 local function BuffLoop(_, _, list, name, icon, _, auraType, _, _, source, _, _, spellID)
-	local spell = list and (oUF:NotSecretValue(spellID) and oUF:NotSecretValue(name)) and (list[spellID] or list[name])
+	if not list then return end
+	if oUF:IsSecretValue(spellID) or oUF:IsSecretValue(name) then return end
+
+	local spell = list[spellID] or list[name]
 	if spell and spell.enable and (not spell.ownOnly or source == 'player') then
 		return auraType, icon, true, spell.style, spell.color
 	end
@@ -45,8 +51,13 @@ end
 
 local function Looper(unit, filter, check, list, func)
 	local unitAuraFiltered = AuraFiltered[filter][unit]
+	if not unitAuraFiltered then return end
+
 	local auraInstanceID, aura = next(unitAuraFiltered)
+	local checked = 0
 	while aura do
+		checked = checked + 1
+		if checked > 40 then return end
 		local name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID = oUF:UnpackAuraData(aura)
 		local AuraType, Icon, filtered, style, color = func(aura, check, list, name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID)
 


### PR DESCRIPTION
## Problem

Midnight can expose some unit-frame values as secret or temporarily unavailable during instanced content. This produced two classes of issues:

- range/aura/fade code could crash on nil or secret values;
- 3D portraits for protected instanced NPC targets could remain blank, or keep a stale model from the previous target.

## Changes

- Add nil guards before next() in range spell lists and aura highlight filtered caches.
- Skip UIFrameFadeOut when startAlpha is a secret value to avoid arithmetic on secrets.
- Make oUF portraits secret-aware:
  - never compare stored secret GUIDs;
  - treat secret UnitIsPlayer returns as non-player for availability checks;
  - avoid repeatedly interrupting model streaming on portrait/model update events;
  - clear stale models for protected targets;
  - keep a 2D portrait fallback behind the PlayerModel when the 3D model cannot be resolved.

## Testing

Tested locally on retail Midnight 120005 in instanced content. Protected NPC targets no longer show the previous grouped target portrait; they show the correct fallback portrait when PlayerModel:SetUnit() does not resolve a 3D model. Group members and normal targets continue to use 3D portraits.