### PR TITLE
fix: guard secret unit frame values and optimize portrait fallback

### DIFF
--- a/ElvUI/Game/Shared/General/Animation.lua
+++ b/ElvUI/Game/Shared/General/Animation.lua
@@ -411,6 +411,7 @@ end
 -- Convenience function to do a simple fade out
 function E:UIFrameFadeOut(frame, timeToFade, startAlpha, endAlpha)
 	if not frame or frame:IsForbidden() then return end
+	if E:IsSecretValue(startAlpha) then return end
 
 	if frame.FadeObject then
 		frame.FadeObject.fadeTimer = nil

--- a/ElvUI/Game/Shared/Modules/ActionBars/PetBar.lua
+++ b/ElvUI/Game/Shared/Modules/ActionBars/PetBar.lua
@@ -28,6 +28,16 @@ local bar = CreateFrame('Frame', 'ElvUI_BarPet', E.UIParent, 'SecureHandlerState
 bar:SetFrameStrata('LOW')
 bar.buttons = {}
 
+local function ClearPetButtonSpellData(button)
+	if button.spellDataLoadedCancelFunc then
+		button.spellDataLoadedCancelFunc()
+		button.spellDataLoadedCancelFunc = nil
+	end
+
+	button.spellDataLoadedSpellID = nil
+	button.tooltipSubtext = nil
+end
+
 function AB:UpdatePet(event, unit)
 	if (event == 'UNIT_FLAGS' and unit ~= 'pet') or (event == 'UNIT_PET' and unit ~= 'player') then return end
 
@@ -54,11 +64,23 @@ function AB:UpdatePet(event, unit)
 			button.tooltipName = _G[name]
 		end
 
-		if spellID then
+		if spellID and button.spellDataLoadedSpellID ~= spellID then
+			ClearPetButtonSpellData(button)
+			button.spellDataLoadedSpellID = spellID
+
 			local spell = _G.Spell:CreateFromSpellID(spellID)
-			button.spellDataLoadedCancelFunc = spell:ContinueWithCancelOnSpellLoad(function()
-				button.tooltipSubtext = spell:GetSpellSubtext()
+			local spellDataLoaded
+			local cancelFunc = spell:ContinueWithCancelOnSpellLoad(function()
+				if button.spellDataLoadedSpellID == spellID then
+					button.tooltipSubtext = spell:GetSpellSubtext()
+					button.spellDataLoadedCancelFunc = nil
+				end
+
+				spellDataLoaded = true
 			end)
+			button.spellDataLoadedCancelFunc = not spellDataLoaded and cancelFunc or nil
+		elseif not spellID and button.spellDataLoadedSpellID then
+			ClearPetButtonSpellData(button)
 		end
 
 		if isActive and name ~= 'PET_ACTION_FOLLOW' then
@@ -227,10 +249,7 @@ end
 
 function AB:PetBar_OnHide()
 	for _, button in ipairs(bar.buttons) do
-		if button.spellDataLoadedCancelFunc then
-			button.spellDataLoadedCancelFunc()
-			button.spellDataLoadedCancelFunc = nil
-		end
+		ClearPetButtonSpellData(button)
 	end
 end
 

--- a/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
@@ -70,7 +70,6 @@ local GetDisplayedItem = TooltipUtil and TooltipUtil.GetDisplayedItem
 local GetItemQualityByID = C_Item.GetItemQualityByID
 local GetItemCount = C_Item.GetItemCount
 local GetItemInfo = C_Item.GetItemInfo
-local GetItemInfoInstant = C_Item.GetItemInfoInstant or GetItemInfoInstant
 
 local GameTooltip, GameTooltipStatusBar = GameTooltip, GameTooltipStatusBar
 local C_QuestLog_GetQuestIDForLogIndex = C_QuestLog.GetQuestIDForLogIndex
@@ -102,58 +101,6 @@ local genderTable = { _G.UNKNOWN..' ', _G.MALE..' ', _G.FEMALE..' ' }
 local blanchyFix = '|n%s*|n' -- thanks blizz -x- lol
 local whiteRGB = { r = 1, g = 1, b = 1, a = 1 }
 local FACTION_CUSTOM = Mixin({}, ColorMixin)
-
-local function SetTooltipHealthText(statusText, unit, current, maximum)
-	if unit then
-		local okCur, unitCurrent = pcall(UnitHealth, unit)
-		local okMax, unitMaximum = pcall(UnitHealthMax, unit)
-		if okCur and okMax then
-			current, maximum = unitCurrent, unitMaximum
-		end
-	end
-
-	if not current or not maximum then return end
-
-	local isDead = current == 0
-	if unit then
-		local okDead, dead = pcall(UnitIsDeadOrGhost, unit)
-		isDead = isDead or (okDead and dead)
-	end
-
-	if isDead then
-		statusText:SetText(_G.DEAD)
-	elseif current > 0 and maximum == 1 then
-		statusText:SetFormattedText('%d%%', floor(current * 100))
-	elseif maximum > 1 then
-		local currentText = TT.db.healthBar.short and E:AbbreviateNumbers(current, 'short') or E:FormatLargeNumber(tostring(current))
-		local maximumText = TT.db.healthBar.short and E:AbbreviateNumbers(maximum, 'short') or E:FormatLargeNumber(tostring(maximum))
-		statusText:SetFormattedText('%s / %s', currentText, maximumText)
-	else
-		return
-	end
-
-	return true
-end
-
-local function GetElvUIBankItemCount(link)
-	local itemID = GetItemInfoInstant and GetItemInfoInstant(link)
-	local bankFrame = itemID and B.BankFrame
-	if not (bankFrame and bankFrame.Bags) then return end
-
-	local count = 0
-	for bagID in next, bankFrame.Bags do
-		if not B.WarbandBanks[bagID] or TT.db.includeWarband then
-			for slotID = 1, B:GetContainerNumSlots(bagID) do
-				local info = B:GetContainerItemInfo(bagID, slotID)
-				if info.itemID == itemID then
-					count = count + (info.stackCount or 1)
-				end
-			end
-		end
-	end
-
-	return count
-end
 
 function TT:IsModKeyDown(db)
 	local k = db or TT.db.modifierID -- defaulted to 'HIDE' unless otherwise specified
@@ -737,7 +684,17 @@ function TT:GameTooltipStatusBar_UpdateUnitHealth(bar)
 	local tt = bar:GetParent()
 	local unit = TT:GetUnitToken(tt)
 
-	if SetTooltipHealthText(statusText, unit) then return end
+	if TT.db.healthBar.short then
+		local okCur, current = pcall(UnitHealth, unit)
+		local okMax, maximum = pcall(UnitHealthMax, unit)
+		if okCur and okMax and current and maximum then
+			local currentAbbrev = E:AbbreviateNumbers(current, 'short')
+			local maximumAbbrev = E:AbbreviateNumbers(maximum, 'short')
+			statusText:SetFormattedText('%s / %s', currentAbbrev, maximumAbbrev)
+
+			return
+		end
+	end
 
 	-- fallback to percent if possible
 	local ok, perc = pcall(UnitHealthPercent, unit, true, ScaleTo100)
@@ -755,12 +712,26 @@ function TT:GameTooltipStatusBar_OnValueChanged(bar, current)
 	local tt = bar:GetParent()
 	local unit = TT:GetUnitToken(tt)
 
-	local maximum
-	if not unit then
-		_, maximum = bar:GetMinMaxValues()
-	end
+	-- check if dead
+	if current == 0 or (unit and UnitIsDeadOrGhost(unit)) then
+		statusText:SetText(_G.DEAD)
+	else
+		local maximum, _
+		if unit then -- try to get the real health values if possible
+			current, maximum = UnitHealth(unit), UnitHealthMax(unit)
+		else
+			_, maximum = bar:GetMinMaxValues()
+		end
 
-	SetTooltipHealthText(statusText, unit, current, maximum)
+		-- return what we got
+		if current > 0 and maximum == 1 then
+			statusText:SetFormattedText('%d%%', floor(current * 100))
+		else
+			local currentShort = E:ShortValue(current)
+			local maximumShort = E:ShortValue(maximum)
+			statusText:SetFormattedText('%s / %s', currentShort, maximumShort)
+		end
+	end
 end
 
 function TT:GameTooltip_OnTooltipCleared(tt)
@@ -847,11 +818,6 @@ function TT:GameTooltip_OnTooltipSetItem(data)
 			if itemCount.bank then
 				local bank = GetItemCount(link, true, nil, TT.db.includeReagents, TT.db.includeWarband)
 				local amount = bank and (bank - count)
-				local elvBank = GetElvUIBankItemCount(link)
-				if elvBank and (not amount or elvBank > amount) then
-					amount = elvBank
-				end
-
 				if amount and amount > 0 then
 					bankCount = format(IDNumber, L["Bank"], amount)
 				end

--- a/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
@@ -70,6 +70,7 @@ local GetDisplayedItem = TooltipUtil and TooltipUtil.GetDisplayedItem
 local GetItemQualityByID = C_Item.GetItemQualityByID
 local GetItemCount = C_Item.GetItemCount
 local GetItemInfo = C_Item.GetItemInfo
+local GetItemInfoInstant = C_Item.GetItemInfoInstant or GetItemInfoInstant
 
 local GameTooltip, GameTooltipStatusBar = GameTooltip, GameTooltipStatusBar
 local C_QuestLog_GetQuestIDForLogIndex = C_QuestLog.GetQuestIDForLogIndex
@@ -101,6 +102,58 @@ local genderTable = { _G.UNKNOWN..' ', _G.MALE..' ', _G.FEMALE..' ' }
 local blanchyFix = '|n%s*|n' -- thanks blizz -x- lol
 local whiteRGB = { r = 1, g = 1, b = 1, a = 1 }
 local FACTION_CUSTOM = Mixin({}, ColorMixin)
+
+local function SetTooltipHealthText(statusText, unit, current, maximum)
+	if unit then
+		local okCur, unitCurrent = pcall(UnitHealth, unit)
+		local okMax, unitMaximum = pcall(UnitHealthMax, unit)
+		if okCur and okMax then
+			current, maximum = unitCurrent, unitMaximum
+		end
+	end
+
+	if not current or not maximum then return end
+
+	local isDead = current == 0
+	if unit then
+		local okDead, dead = pcall(UnitIsDeadOrGhost, unit)
+		isDead = isDead or (okDead and dead)
+	end
+
+	if isDead then
+		statusText:SetText(_G.DEAD)
+	elseif current > 0 and maximum == 1 then
+		statusText:SetFormattedText('%d%%', floor(current * 100))
+	elseif maximum > 1 then
+		local currentText = TT.db.healthBar.short and E:AbbreviateNumbers(current, 'short') or E:FormatLargeNumber(tostring(current))
+		local maximumText = TT.db.healthBar.short and E:AbbreviateNumbers(maximum, 'short') or E:FormatLargeNumber(tostring(maximum))
+		statusText:SetFormattedText('%s / %s', currentText, maximumText)
+	else
+		return
+	end
+
+	return true
+end
+
+local function GetElvUIBankItemCount(link)
+	local itemID = GetItemInfoInstant and GetItemInfoInstant(link)
+	local bankFrame = itemID and B.BankFrame
+	if not (bankFrame and bankFrame.Bags) then return end
+
+	local count = 0
+	for bagID in next, bankFrame.Bags do
+		if not B.WarbandBanks[bagID] or TT.db.includeWarband then
+			for slotID = 1, B:GetContainerNumSlots(bagID) do
+				local info = B:GetContainerItemInfo(bagID, slotID)
+				if info.itemID == itemID then
+					count = count + (info.stackCount or 1)
+				end
+			end
+		end
+	end
+
+	return count
+end
 
 function TT:IsModKeyDown(db)
 	local k = db or TT.db.modifierID -- defaulted to 'HIDE' unless otherwise specified
@@ -684,17 +737,7 @@ function TT:GameTooltipStatusBar_UpdateUnitHealth(bar)
 	local tt = bar:GetParent()
 	local unit = TT:GetUnitToken(tt)
 
-	if TT.db.healthBar.short then
-		local okCur, current = pcall(UnitHealth, unit)
-		local okMax, maximum = pcall(UnitHealthMax, unit)
-		if okCur and okMax and current and maximum then
-			local currentAbbrev = E:AbbreviateNumbers(current, 'short')
-			local maximumAbbrev = E:AbbreviateNumbers(maximum, 'short')
-			statusText:SetFormattedText('%s / %s', currentAbbrev, maximumAbbrev)
-
-			return
-		end
-	end
+	if SetTooltipHealthText(statusText, unit) then return end
 
 	-- fallback to percent if possible
 	local ok, perc = pcall(UnitHealthPercent, unit, true, ScaleTo100)
@@ -712,26 +755,12 @@ function TT:GameTooltipStatusBar_OnValueChanged(bar, current)
 	local tt = bar:GetParent()
 	local unit = TT:GetUnitToken(tt)
 
-	-- check if dead
-	if current == 0 or (unit and UnitIsDeadOrGhost(unit)) then
-		statusText:SetText(_G.DEAD)
-	else
-		local maximum, _
-		if unit then -- try to get the real health values if possible
-			current, maximum = UnitHealth(unit), UnitHealthMax(unit)
-		else
-			_, maximum = bar:GetMinMaxValues()
-		end
-
-		-- return what we got
-		if current > 0 and maximum == 1 then
-			statusText:SetFormattedText('%d%%', floor(current * 100))
-		else
-			local currentShort = E:ShortValue(current)
-			local maximumShort = E:ShortValue(maximum)
-			statusText:SetFormattedText('%s / %s', currentShort, maximumShort)
-		end
+	local maximum
+	if not unit then
+		_, maximum = bar:GetMinMaxValues()
 	end
+
+	SetTooltipHealthText(statusText, unit, current, maximum)
 end
 
 function TT:GameTooltip_OnTooltipCleared(tt)
@@ -818,6 +847,11 @@ function TT:GameTooltip_OnTooltipSetItem(data)
 			if itemCount.bank then
 				local bank = GetItemCount(link, true, nil, TT.db.includeReagents, TT.db.includeWarband)
 				local amount = bank and (bank - count)
+				local elvBank = GetElvUIBankItemCount(link)
+				if elvBank and (not amount or elvBank > amount) then
+					amount = elvBank
+				end
+
 				if amount and amount > 0 then
 					bankCount = format(IDNumber, L["Bank"], amount)
 				end

--- a/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
@@ -1192,7 +1192,9 @@ function TT:Initialize()
 	TT:SecureHook('GameTooltip_SetDefaultAnchor')
 	TT:SecureHook('EmbeddedItemTooltip_SetItemByID', 'EmbeddedItemTooltip_ID')
 	TT:SecureHook('EmbeddedItemTooltip_SetCurrencyByID', 'EmbeddedItemTooltip_ID')
-	TT:SecureHook('EmbeddedItemTooltip_SetItemByQuestReward', 'EmbeddedItemTooltip_QuestReward')
+	-- Do not hook quest reward embedded tooltips on Retail. Blizzard's
+	-- EmbeddedItemTooltip_UpdateSize can receive secret sizes there, and
+	-- running that path in ElvUI's hooked execution taints arithmetic.
 	TT:SecureHook(GameTooltip, 'SetUnitAura')
 	TT:SecureHook(GameTooltip, 'SetUnitBuff', 'SetUnitAura')
 	TT:SecureHook(GameTooltip, 'SetUnitDebuff', 'SetUnitAura')
@@ -1229,7 +1231,6 @@ function TT:Initialize()
 		TT:RegisterEvent('WORLD_CURSOR_TOOLTIP_UPDATE', 'WorldCursorTooltipUpdate')
 
 		TT:SecureHook('EmbeddedItemTooltip_SetSpellWithTextureByID', 'EmbeddedItemTooltip_ID')
-		TT:SecureHook('EmbeddedItemTooltip_SetSpellByQuestReward', 'EmbeddedItemTooltip_QuestReward')
 		TT:SecureHook(GameTooltipStatusBar, 'UpdateUnitHealth', 'GameTooltipStatusBar_UpdateUnitHealth')
 
 		TT:SecureHook(GameTooltip, 'SetCurrencyByID')

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -9,6 +9,52 @@ local UnitClass = UnitClass
 
 local classIcon = [[Interface\WorldStateFrame\Icons-Classes]]
 
+local UnitGUID = UnitGUID
+local UnitIsPlayer = UnitIsPlayer
+local UnitIsVisible = UnitIsVisible
+local UnitIsConnected = UnitIsConnected
+local SetPortraitTexture = SetPortraitTexture
+local IsUnitModelReadyForUI = IsUnitModelReadyForUI
+
+local function HidePortraitFallback(element)
+	if element.Fallback2D then
+		element.Fallback2D:Hide()
+	end
+
+	element.secretRetryUnit = nil
+	element.secretRetryCount = nil
+end
+
+local function RetrySecretPortrait(element, unit)
+	if not C_Timer then return end
+	if element.secretRetryUnit == unit then return end
+
+	element.secretRetryUnit = unit
+	element.secretRetryCount = 0
+
+	local function retry()
+		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
+
+		element.secretRetryCount = (element.secretRetryCount or 0) + 1
+		element:SetUnit(unit)
+
+		if element.secretRetryCount < 4 then
+			C_Timer.After(0.2 * element.secretRetryCount, retry)
+		end
+	end
+
+	C_Timer.After(0.1, retry)
+end
+
+function UF.PortraitForceUpdate(frame, event, unit)
+	if unit == frame.unit then
+		local element = frame.Portrait
+		if element and element.ForceUpdate then
+			element:ForceUpdate()
+		end
+	end
+end
+
 function UF:ModelAlphaFix(value)
 	local portrait = self.Portrait3D
 	if not portrait then return end
@@ -17,6 +63,103 @@ function UF:ModelAlphaFix(value)
 	local modelAlpha = value * (E:IsSecretValue(alpha) and 1 or alpha)
 	portrait:SetModelAlpha(modelAlpha)
 	portrait.backdrop:SetAlpha(modelAlpha)
+end
+
+function UF:PortraitOverride(event)
+	local element = self.Portrait
+	if not element then return end
+
+	local unit = self.unit
+	if not unit then return end
+
+	local guid = UnitGUID(unit)
+	local secretGUID = E:IsSecretValue(guid)
+	local storedGUID = element.guid
+	local secretStoredGUID = E:IsSecretValue(storedGUID)
+	local newGUID = secretGUID or secretStoredGUID or (storedGUID ~= guid)
+
+	local nameplate = event == 'NAME_PLATE_UNIT_ADDED'
+	if newGUID then
+		element.secretRetryUnit = nil
+		element.secretRetryCount = nil
+		element.guid = not secretGUID and guid or nil
+	elseif nameplate then
+		return
+	end
+
+	if element.PreUpdate then element:PreUpdate(unit) end
+
+	local isPlayerRaw = UnitIsPlayer(unit)
+	local isPlayer = (isPlayerRaw == true)
+	local isSecret = E:IsSecretValue(isPlayerRaw)
+	local isVisible = not isPlayer or UnitIsVisible(unit)
+	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (IsUnitModelReadyForUI(unit) and UnitIsConnected(unit)))
+
+	local hasStateChanged = newGUID or (not nameplate or element.state ~= isAvailable)
+	if hasStateChanged then
+		element.playerModel = element:IsObjectType('PlayerModel')
+		local prevState = element.state
+		element.state = isAvailable
+
+		if element.playerModel then
+			if not element.modelLoadedHooked then
+				element.modelLoadedHooked = true
+				pcall(element.HookScript, element, "OnModelLoaded", HidePortraitFallback)
+			end
+
+			if isAvailable then
+				if element.Fallback2D and not secretGUID then
+					HidePortraitFallback(element)
+				end
+
+				element:SetCamDistanceScale(1)
+				element:SetPortraitZoom(1)
+				element:SetPosition(0, 0, 0)
+
+				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
+				local needsLoad = (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				if needsLoad then
+					if secretGUID then
+						element:ClearModel()
+						if not element.Fallback2D then
+							local fallback = element:CreateTexture(nil, "BACKGROUND")
+							fallback:SetAllPoints(element)
+							fallback:SetTexCoord(0.15, 0.85, 0.15, 0.85)
+							element.Fallback2D = fallback
+						else
+							element.Fallback2D:SetDrawLayer("BACKGROUND")
+						end
+						SetPortraitTexture(element.Fallback2D, unit)
+						element.Fallback2D:Show()
+					end
+
+					element:SetUnit(unit)
+
+					if secretGUID then
+						RetrySecretPortrait(element, unit)
+					end
+				end
+			else
+				HidePortraitFallback(element)
+				element:ClearModel()
+				element:SetCamDistanceScale(0.25)
+				element:SetPortraitZoom(0)
+				element:SetPosition(0, 0, 0.25)
+				element:SetModel([[Interface\Buttons\TalkToMeQuestionMark.m2]])
+			end
+		elseif element.useClassBase then
+			local _, className = UnitClass(unit)
+			if className then
+				element:SetAtlas('classicon-' .. className)
+			end
+		elseif not element.customTexture then
+			SetPortraitTexture(element, unit)
+		end
+	end
+
+	if element.PostUpdate then
+		return element:PostUpdate(unit, hasStateChanged)
+	end
 end
 
 function UF:Construct_Portrait(frame, which)
@@ -43,6 +186,7 @@ function UF:Construct_Portrait(frame, which)
 
 	portrait.__owner = frame -- set this for both, oUF will only set it when active
 	portrait.PostUpdate = UF.PortraitUpdate
+	portrait.Override = UF.PortraitOverride
 
 	return portrait
 end
@@ -76,8 +220,10 @@ function UF:Configure_Portrait(frame)
 
 		if portrait.db.style == '3D' then
 			portrait:OffsetFrameLevel(nil, frame.Health)
+			frame:RegisterEvent('UNIT_PORTRAIT_UPDATE', UF.PortraitForceUpdate)
 		else
 			portrait:SetParent(frame.USE_PORTRAIT_OVERLAY and frame.Health or frame)
+			frame:UnregisterEvent('UNIT_PORTRAIT_UPDATE', UF.PortraitForceUpdate)
 		end
 
 		portrait:ClearAllPoints()
@@ -141,6 +287,7 @@ function UF:Configure_Portrait(frame)
 		end
 	elseif frame:IsElementEnabled('Portrait') then
 		frame:DisableElement('Portrait')
+		frame:UnregisterEvent('UNIT_PORTRAIT_UPDATE', UF.PortraitForceUpdate)
 	end
 end
 

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -175,6 +175,9 @@ function UF:PortraitOverride(event)
 				local needsLoad = needsModel or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
 				if needsLoad then
 					if secretGUID then
+						-- SetUnit for a secret-GUID unit loads a stale cached model
+						-- (usually the previous target's model). Never call it; the 2D
+						-- fallback is the permanent solution for non-grouped instance units.
 						element:ClearModel()
 						if not element.Fallback2D then
 							local fallback = element:CreateTexture(nil, "BACKGROUND")
@@ -186,17 +189,15 @@ function UF:PortraitOverride(event)
 						end
 						SetPortraitTexture(element.Fallback2D, unit)
 						element.Fallback2D:Show()
-					end
-
-					element:SetUnit(unit)
-
-					if HidePortraitFallbackIfLoaded(element) then
-						element.modelRetryUnit = nil
-						element.modelRetryCount = nil
 					else
-						RetryPortraitModel(element, unit)
-						if secretGUID then
-							RetrySecretPortrait(element, unit)
+						HidePortraitFallback(element)
+						element:SetUnit(unit)
+
+						if HidePortraitFallbackIfLoaded(element) then
+							element.modelRetryUnit = nil
+							element.modelRetryCount = nil
+						else
+							RetryPortraitModel(element, unit)
 						end
 					end
 				end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -17,6 +17,9 @@ local SetPortraitTexture = SetPortraitTexture
 local IsUnitModelReadyForUI = IsUnitModelReadyForUI
 
 local function HidePortraitFallback(element)
+	if element.Fallback2DFrame then
+		element.Fallback2DFrame:Hide()
+	end
 	if element.Fallback2D then
 		element.Fallback2D:Hide()
 	end
@@ -30,9 +33,24 @@ local function HasPortraitModel(element)
 end
 
 local function HidePortraitFallbackIfLoaded(element)
+	if element.hasSecretUnit then return false end -- handled by OnModelLoadedCheck
 	if HasPortraitModel(element) then
 		HidePortraitFallback(element)
 		return true
+	end
+end
+
+-- Fired by OnModelLoaded. For secret-GUID units, only hide the 2D cover when a
+-- DIFFERENT model file has loaded — that means the real NPC 3D model streamed in.
+-- A same-ID fire means the stale cached model was re-applied; keep the 2D cover.
+local function OnModelLoadedCheck(element)
+	if element.hasSecretUnit then
+		local newID = element:GetModelFileID()
+		if newID and newID ~= element.secretPreloadModelID then
+			HidePortraitFallback(element)
+		end
+	else
+		HidePortraitFallback(element)
 	end
 end
 
@@ -120,6 +138,7 @@ function UF:PortraitOverride(event)
 
 	local guid = UnitGUID(unit)
 	local secretGUID = E:IsSecretValue(guid)
+	element.hasSecretUnit = secretGUID
 	local storedGUID = element.guid
 	local secretStoredGUID = E:IsSecretValue(storedGUID)
 	local newGUID = secretGUID or secretStoredGUID or (storedGUID ~= guid)
@@ -158,7 +177,7 @@ function UF:PortraitOverride(event)
 		if element.playerModel then
 			if not element.modelLoadedHooked then
 				element.modelLoadedHooked = true
-				pcall(element.HookScript, element, "OnModelLoaded", HidePortraitFallback)
+				pcall(element.HookScript, element, "OnModelLoaded", OnModelLoadedCheck)
 			end
 
 			if isAvailable then
@@ -172,23 +191,36 @@ function UF:PortraitOverride(event)
 				element:SetPosition(0, 0, 0)
 
 				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
-				local needsLoad = needsModel or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				-- For secret-GUID units, needsModel and newGUID are always truthy
+				-- (secret values can't be compared), so exclude them to avoid OnUpdate loops.
+				local needsLoad = (not secretGUID and needsModel) or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
 				if needsLoad then
 					if secretGUID then
-						-- SetUnit for a secret-GUID unit loads a stale cached model
-						-- (usually the previous target's model). Never call it; the 2D
-						-- fallback is the permanent solution for non-grouped instance units.
-						element:ClearModel()
-						if not element.Fallback2D then
-							local fallback = element:CreateTexture(nil, "BACKGROUND")
-							fallback:SetAllPoints(element)
-							fallback:SetTexCoord(0.15, 0.85, 0.15, 0.85)
-							element.Fallback2D = fallback
-						else
-							element.Fallback2D:SetDrawLayer("BACKGROUND")
+						-- Show a 2D cover frame immediately so any stale cached 3D model
+						-- (from the previous target) is hidden while we try to load the real
+						-- NPC model. The cover is a child Frame placed above the PlayerModel,
+						-- so it renders on top of any 3D content regardless of draw layers.
+						-- SetUnit is called WITHOUT ClearModel so the old model stays as an
+						-- invisible placeholder; if the NPC's actual model streams in,
+						-- OnModelLoadedCheck detects the new file ID and hides the cover.
+						if not element.Fallback2DFrame then
+							local cover = CreateFrame("Frame", nil, element)
+							cover:SetAllPoints(element)
+							local tex = cover:CreateTexture(nil, "BACKGROUND")
+							tex:SetAllPoints(cover)
+							tex:SetTexCoord(0.15, 0.85, 0.15, 0.85)
+							element.Fallback2D = tex
+							element.Fallback2DFrame = cover
 						end
+						element.Fallback2DFrame:SetFrameLevel(element:GetFrameLevel() + 5)
 						SetPortraitTexture(element.Fallback2D, unit)
+						element.Fallback2DFrame:Show()
 						element.Fallback2D:Show()
+
+						-- Snapshot the current model ID before SetUnit so OnModelLoadedCheck
+						-- can tell a real new NPC load from a stale cache hit.
+						element.secretPreloadModelID = element:GetModelFileID()
+						element:SetUnit(unit)
 					else
 						HidePortraitFallback(element)
 						element:SetUnit(unit)

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -25,6 +25,50 @@ local function HidePortraitFallback(element)
 	element.secretRetryCount = nil
 end
 
+local function HasPortraitModel(element)
+	return not element.GetModelFileID or element:GetModelFileID()
+end
+
+local function HidePortraitFallbackIfLoaded(element)
+	if HasPortraitModel(element) then
+		HidePortraitFallback(element)
+		return true
+	end
+end
+
+local function RetryPortraitModel(element, unit)
+	if not C_Timer then return end
+	if element.modelRetryUnit == unit then return end
+
+	element.modelRetryUnit = unit
+	element.modelRetryCount = 0
+
+	local function retry()
+		if element.modelRetryUnit ~= unit or not element:IsShown() then return end
+		if HidePortraitFallbackIfLoaded(element) then
+			element.modelRetryUnit = nil
+			element.modelRetryCount = nil
+			return
+		end
+
+		local retryCount = (element.modelRetryCount or 0) + 1
+		element.modelRetryCount = retryCount
+		element:ClearModel()
+		element:SetUnit(unit)
+		if HidePortraitFallbackIfLoaded(element) then
+			element.modelRetryUnit = nil
+			element.modelRetryCount = nil
+			return
+		end
+
+		if element.modelRetryUnit == unit and retryCount < 10 then
+			C_Timer.After(0.25 * retryCount, retry)
+		end
+	end
+
+	C_Timer.After(0.1, retry)
+end
+
 local function RetrySecretPortrait(element, unit)
 	if not C_Timer then return end
 	if element.secretRetryUnit == unit then return end
@@ -69,6 +113,7 @@ end
 function UF:PortraitOverride(event)
 	local element = self.Portrait
 	if not element then return end
+	element.elvPortraitPatch = 1
 
 	local unit = self.unit
 	if not unit then return end
@@ -83,6 +128,8 @@ function UF:PortraitOverride(event)
 	if newGUID then
 		element.secretRetryUnit = nil
 		element.secretRetryCount = nil
+		element.modelRetryUnit = nil
+		element.modelRetryCount = nil
 		element.guid = not secretGUID and guid or nil
 	elseif nameplate then
 		return
@@ -99,10 +146,12 @@ function UF:PortraitOverride(event)
 	local isConnected = E:IsSecretValue(isConnectedRaw) or (isConnectedRaw == true)
 	local isModelReady = IsUnitModelReadyForUI and IsUnitModelReadyForUI(unit)
 	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (isModelReady and isConnected))
+	local playerModel = element:IsObjectType('PlayerModel')
+	local needsModel = playerModel and isAvailable and not HasPortraitModel(element)
 
-	local hasStateChanged = newGUID or (not nameplate or element.state ~= isAvailable)
+	local hasStateChanged = newGUID or needsModel or (not nameplate or element.state ~= isAvailable)
 	if hasStateChanged then
-		element.playerModel = element:IsObjectType('PlayerModel')
+		element.playerModel = playerModel
 		local prevState = element.state
 		element.state = isAvailable
 
@@ -113,8 +162,9 @@ function UF:PortraitOverride(event)
 			end
 
 			if isAvailable then
-				if element.Fallback2D and not secretGUID then
-					HidePortraitFallback(element)
+				if element.Fallback2D and HidePortraitFallbackIfLoaded(element) then
+					element.modelRetryUnit = nil
+					element.modelRetryCount = nil
 				end
 
 				element:SetCamDistanceScale(1)
@@ -122,7 +172,7 @@ function UF:PortraitOverride(event)
 				element:SetPosition(0, 0, 0)
 
 				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
-				local needsLoad = (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				local needsLoad = needsModel or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
 				if needsLoad then
 					if secretGUID then
 						element:ClearModel()
@@ -140,12 +190,20 @@ function UF:PortraitOverride(event)
 
 					element:SetUnit(unit)
 
-					if secretGUID then
-						RetrySecretPortrait(element, unit)
+					if HidePortraitFallbackIfLoaded(element) then
+						element.modelRetryUnit = nil
+						element.modelRetryCount = nil
+					else
+						RetryPortraitModel(element, unit)
+						if secretGUID then
+							RetrySecretPortrait(element, unit)
+						end
 					end
 				end
 			else
 				HidePortraitFallback(element)
+				element.modelRetryUnit = nil
+				element.modelRetryCount = nil
 				element:ClearModel()
 				element:SetCamDistanceScale(0.25)
 				element:SetPortraitZoom(0)

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -35,11 +35,12 @@ local function RetrySecretPortrait(element, unit)
 	local function retry()
 		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
 
-		element.secretRetryCount = (element.secretRetryCount or 0) + 1
+		local retryCount = (element.secretRetryCount or 0) + 1
+		element.secretRetryCount = retryCount
 		element:SetUnit(unit)
 
-		if element.secretRetryCount < 4 then
-			C_Timer.After(0.2 * element.secretRetryCount, retry)
+		if element.secretRetryUnit == unit and retryCount < 4 then
+			C_Timer.After(0.2 * retryCount, retry)
 		end
 	end
 
@@ -92,8 +93,12 @@ function UF:PortraitOverride(event)
 	local isPlayerRaw = UnitIsPlayer(unit)
 	local isPlayer = (isPlayerRaw == true)
 	local isSecret = E:IsSecretValue(isPlayerRaw)
-	local isVisible = not isPlayer or UnitIsVisible(unit)
-	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (IsUnitModelReadyForUI(unit) and UnitIsConnected(unit)))
+	local isVisibleRaw = UnitIsVisible(unit)
+	local isVisible = not isPlayer or E:IsSecretValue(isVisibleRaw) or (isVisibleRaw == true)
+	local isConnectedRaw = UnitIsConnected(unit)
+	local isConnected = E:IsSecretValue(isConnectedRaw) or (isConnectedRaw == true)
+	local isModelReady = IsUnitModelReadyForUI and IsUnitModelReadyForUI(unit)
+	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (isModelReady and isConnected))
 
 	local hasStateChanged = newGUID or (not nameplate or element.state ~= isAvailable)
 	if hasStateChanged then

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua
@@ -26,6 +26,8 @@ local list = {}
 UF.RangeSpells = list
 
 function UF:UpdateRangeList(db)
+	if not db then return {} end
+
 	local spells = {}
 	for spell, value in next, db do
 		if value then
@@ -78,6 +80,8 @@ end
 
 function UF:UnitInSpellsRange(unit, which)
 	local spells = list[which]
+	if not spells then return nil end
+
 	local range = (not next(spells) and 1) or UF:UnitSpellRange(unit, spells)
 
 	if (not range or range == 1) and not InCombatLockdown() then

--- a/ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua
@@ -42,41 +42,9 @@ local oUF = ns.oUF
 local UnitGUID = UnitGUID
 local UnitClass = UnitClass
 local UnitIsVisible = UnitIsVisible
-local UnitIsPlayer = UnitIsPlayer
 local UnitIsConnected = UnitIsConnected
 local SetPortraitTexture = SetPortraitTexture
-local C_Timer = C_Timer
 local IsUnitModelReadyForUI = IsUnitModelReadyForUI
-
-local function HidePortraitFallback(element)
-	if element.Fallback2D then
-		element.Fallback2D:Hide()
-	end
-
-	element.secretRetryUnit = nil
-	element.secretRetryCount = nil
-end
-
-local function RetrySecretPortrait(element, unit)
-	if not C_Timer then return end
-	if element.secretRetryUnit == unit then return end
-
-	element.secretRetryUnit = unit
-	element.secretRetryCount = 0
-
-	local function retry()
-		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
-
-		element.secretRetryCount = (element.secretRetryCount or 0) + 1
-		element:SetUnit(unit)
-
-		if element.secretRetryCount < 4 then
-			C_Timer.After(0.2 * element.secretRetryCount, retry)
-		end
-	end
-
-	C_Timer.After(0.1, retry)
-end
 
 local function Update(self, event)
 	local element = self.Portrait
@@ -87,14 +55,10 @@ local function Update(self, event)
 
 	local guid = UnitGUID(unit)
 	local secretGUID = oUF:IsSecretValue(guid)
-	local storedGUID = element.guid
-	local secretStoredGUID = oUF:IsSecretValue(storedGUID)
-	local newGUID = secretGUID or secretStoredGUID or (storedGUID ~= guid)
+	local newGUID = secretGUID or (element.guid ~= guid)
 
 	local nameplate = event == 'NAME_PLATE_UNIT_ADDED'
 	if newGUID then
-		element.secretRetryUnit = nil
-		element.secretRetryCount = nil
 		element.guid = not secretGUID and guid or nil
 	elseif nameplate then
 		return
@@ -108,73 +72,21 @@ local function Update(self, event)
 	--]]
 	if(element.PreUpdate) then element:PreUpdate(unit) end
 
-	-- In Midnight, UnitIsPlayer returns a secret boolean for instanced NPCs.
-	-- A secret boolean is truthy in Lua, so `not secretFalse == false`, which
-	-- incorrectly treats NPCs as players and forces IsUnitModelReadyForUI checks.
-	local isPlayerRaw = UnitIsPlayer(unit)
-	local isPlayer = (isPlayerRaw == true)
-	local isSecret = oUF:IsSecretValue(isPlayerRaw)
-	local isVisible = not isPlayer or UnitIsVisible(unit)
-	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (IsUnitModelReadyForUI(unit) and UnitIsConnected(unit)))
+	local isAvailable = element:IsVisible() and IsUnitModelReadyForUI(unit) and UnitIsConnected(unit) and UnitIsVisible(unit)
 	local hasStateChanged = newGUID or (not nameplate or element.state ~= isAvailable)
 	if hasStateChanged then
 		element.playerModel = element:IsObjectType('PlayerModel')
-		local prevState = element.state
 		element.state = isAvailable
 
 		if element.playerModel then
-			if not element.modelLoadedHooked then
-				element.modelLoadedHooked = true
-				pcall(element.HookScript, element, "OnModelLoaded", HidePortraitFallback)
-			end
+			element:ClearModel()
+			element:SetCamDistanceScale(isAvailable and 1 or 0.25)
+			element:SetPortraitZoom(isAvailable and 1 or 0)
+			element:SetPosition(0, 0, isAvailable and 0 or 0.25)
 
 			if isAvailable then
-				if element.Fallback2D and not secretGUID then
-					HidePortraitFallback(element)
-				end
-
-				element:SetCamDistanceScale(1)
-				element:SetPortraitZoom(1)
-				element:SetPosition(0, 0, 0)
-				-- For secret GUIDs (dungeon/raid units in Midnight), newGUID is always true.
-				-- These events fire repeatedly without a genuine unit change (streaming, party status,
-				-- connection state) and would abort async model loading if they triggered SetUnit.
-				-- OnShow is added explicitly: when a frame re-appears (new pull, pet revival) with
-				-- the same GUID, the engine may have cleared the model while the frame was hidden.
-				-- UNIT_MODEL_CHANGED in Midnight fires when SetUnit starts streaming, not only on
-				-- genuine model changes. Allowing it for secret GUIDs causes SetUnit→event→SetUnit loops.
-				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
-				local needsLoad = (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
-				if needsLoad then
-					if secretGUID then
-						element:ClearModel()
-
-						if not element.Fallback2D then
-							local fallback = element:CreateTexture(nil, "BACKGROUND")
-							fallback:SetAllPoints(element)
-							fallback:SetTexCoord(0.15, 0.85, 0.15, 0.85)
-							element.Fallback2D = fallback
-						else
-							element.Fallback2D:SetDrawLayer("BACKGROUND")
-						end
-
-						SetPortraitTexture(element.Fallback2D, unit)
-						element.Fallback2D:Show()
-					end
-
-					element:SetUnit(unit)
-
-					if secretGUID then
-						RetrySecretPortrait(element, unit)
-					end
-				end
+				element:SetUnit(unit)
 			else
-				HidePortraitFallback(element)
-
-				element:ClearModel()
-				element:SetCamDistanceScale(0.25)
-				element:SetPortraitZoom(0)
-				element:SetPosition(0, 0, 0.25)
 				element:SetModel([[Interface\Buttons\TalkToMeQuestionMark.m2]])
 			end
 		elseif element.useClassBase then
@@ -226,7 +138,6 @@ local function Enable(self, unit)
 		local playerModel = element:IsObjectType('PlayerModel')
 		if playerModel then
 			self:RegisterEvent('UNIT_MODEL_CHANGED', Path)
-			self:RegisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 		else
 			self:RegisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 			self:RegisterEvent('PORTRAITS_UPDATED', Path, true)
@@ -254,12 +165,9 @@ local function Disable(self)
 
 		local playerModel = element:IsObjectType('PlayerModel')
 		if playerModel then
-			HidePortraitFallback(element)
-
 			element:ClearModel()
 
 			self:UnregisterEvent('UNIT_MODEL_CHANGED', Path)
-			self:UnregisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 		else
 			self:UnregisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 			self:UnregisterEvent('PORTRAITS_UPDATED', Path)

--- a/ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua
@@ -42,9 +42,41 @@ local oUF = ns.oUF
 local UnitGUID = UnitGUID
 local UnitClass = UnitClass
 local UnitIsVisible = UnitIsVisible
+local UnitIsPlayer = UnitIsPlayer
 local UnitIsConnected = UnitIsConnected
 local SetPortraitTexture = SetPortraitTexture
+local C_Timer = C_Timer
 local IsUnitModelReadyForUI = IsUnitModelReadyForUI
+
+local function HidePortraitFallback(element)
+	if element.Fallback2D then
+		element.Fallback2D:Hide()
+	end
+
+	element.secretRetryUnit = nil
+	element.secretRetryCount = nil
+end
+
+local function RetrySecretPortrait(element, unit)
+	if not C_Timer then return end
+	if element.secretRetryUnit == unit then return end
+
+	element.secretRetryUnit = unit
+	element.secretRetryCount = 0
+
+	local function retry()
+		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
+
+		element.secretRetryCount = (element.secretRetryCount or 0) + 1
+		element:SetUnit(unit)
+
+		if element.secretRetryCount < 4 then
+			C_Timer.After(0.2 * element.secretRetryCount, retry)
+		end
+	end
+
+	C_Timer.After(0.1, retry)
+end
 
 local function Update(self, event)
 	local element = self.Portrait
@@ -55,10 +87,14 @@ local function Update(self, event)
 
 	local guid = UnitGUID(unit)
 	local secretGUID = oUF:IsSecretValue(guid)
-	local newGUID = secretGUID or (element.guid ~= guid)
+	local storedGUID = element.guid
+	local secretStoredGUID = oUF:IsSecretValue(storedGUID)
+	local newGUID = secretGUID or secretStoredGUID or (storedGUID ~= guid)
 
 	local nameplate = event == 'NAME_PLATE_UNIT_ADDED'
 	if newGUID then
+		element.secretRetryUnit = nil
+		element.secretRetryCount = nil
 		element.guid = not secretGUID and guid or nil
 	elseif nameplate then
 		return
@@ -72,21 +108,73 @@ local function Update(self, event)
 	--]]
 	if(element.PreUpdate) then element:PreUpdate(unit) end
 
-	local isAvailable = element:IsVisible() and IsUnitModelReadyForUI(unit) and UnitIsConnected(unit) and UnitIsVisible(unit)
+	-- In Midnight, UnitIsPlayer returns a secret boolean for instanced NPCs.
+	-- A secret boolean is truthy in Lua, so `not secretFalse == false`, which
+	-- incorrectly treats NPCs as players and forces IsUnitModelReadyForUI checks.
+	local isPlayerRaw = UnitIsPlayer(unit)
+	local isPlayer = (isPlayerRaw == true)
+	local isSecret = oUF:IsSecretValue(isPlayerRaw)
+	local isVisible = not isPlayer or UnitIsVisible(unit)
+	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (IsUnitModelReadyForUI(unit) and UnitIsConnected(unit)))
 	local hasStateChanged = newGUID or (not nameplate or element.state ~= isAvailable)
 	if hasStateChanged then
 		element.playerModel = element:IsObjectType('PlayerModel')
+		local prevState = element.state
 		element.state = isAvailable
 
 		if element.playerModel then
-			element:ClearModel()
-			element:SetCamDistanceScale(isAvailable and 1 or 0.25)
-			element:SetPortraitZoom(isAvailable and 1 or 0)
-			element:SetPosition(0, 0, isAvailable and 0 or 0.25)
+			if not element.modelLoadedHooked then
+				element.modelLoadedHooked = true
+				pcall(element.HookScript, element, "OnModelLoaded", HidePortraitFallback)
+			end
 
 			if isAvailable then
-				element:SetUnit(unit)
+				if element.Fallback2D and not secretGUID then
+					HidePortraitFallback(element)
+				end
+
+				element:SetCamDistanceScale(1)
+				element:SetPortraitZoom(1)
+				element:SetPosition(0, 0, 0)
+				-- For secret GUIDs (dungeon/raid units in Midnight), newGUID is always true.
+				-- These events fire repeatedly without a genuine unit change (streaming, party status,
+				-- connection state) and would abort async model loading if they triggered SetUnit.
+				-- OnShow is added explicitly: when a frame re-appears (new pull, pet revival) with
+				-- the same GUID, the engine may have cleared the model while the frame was hidden.
+				-- UNIT_MODEL_CHANGED in Midnight fires when SetUnit starts streaming, not only on
+				-- genuine model changes. Allowing it for secret GUIDs causes SetUnit→event→SetUnit loops.
+				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
+				local needsLoad = (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				if needsLoad then
+					if secretGUID then
+						element:ClearModel()
+
+						if not element.Fallback2D then
+							local fallback = element:CreateTexture(nil, "BACKGROUND")
+							fallback:SetAllPoints(element)
+							fallback:SetTexCoord(0.15, 0.85, 0.15, 0.85)
+							element.Fallback2D = fallback
+						else
+							element.Fallback2D:SetDrawLayer("BACKGROUND")
+						end
+
+						SetPortraitTexture(element.Fallback2D, unit)
+						element.Fallback2D:Show()
+					end
+
+					element:SetUnit(unit)
+
+					if secretGUID then
+						RetrySecretPortrait(element, unit)
+					end
+				end
 			else
+				HidePortraitFallback(element)
+
+				element:ClearModel()
+				element:SetCamDistanceScale(0.25)
+				element:SetPortraitZoom(0)
+				element:SetPosition(0, 0, 0.25)
 				element:SetModel([[Interface\Buttons\TalkToMeQuestionMark.m2]])
 			end
 		elseif element.useClassBase then
@@ -138,6 +226,7 @@ local function Enable(self, unit)
 		local playerModel = element:IsObjectType('PlayerModel')
 		if playerModel then
 			self:RegisterEvent('UNIT_MODEL_CHANGED', Path)
+			self:RegisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 		else
 			self:RegisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 			self:RegisterEvent('PORTRAITS_UPDATED', Path, true)
@@ -165,9 +254,12 @@ local function Disable(self)
 
 		local playerModel = element:IsObjectType('PlayerModel')
 		if playerModel then
+			HidePortraitFallback(element)
+
 			element:ClearModel()
 
 			self:UnregisterEvent('UNIT_MODEL_CHANGED', Path)
+			self:UnregisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 		else
 			self:UnregisterEvent('UNIT_PORTRAIT_UPDATE', Path)
 			self:UnregisterEvent('PORTRAITS_UPDATED', Path)

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraBars.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraBars.lua
@@ -247,13 +247,28 @@ end
 
 local function FilterBars(frame, element, unit, filter, limit, isDebuff, offset, dontHide)
 	if(not offset) then offset = 0 end
+
+	local unitAuraFiltered = AuraFiltered[filter][unit]
+	if not unitAuraFiltered then return 0, 0 end
+
+	local temp = {}
+	local count = 0
+	for auraInstanceID, aura in next, unitAuraFiltered do
+		count = count + 1
+		temp[count] = auraInstanceID
+		count = count + 1
+		temp[count] = aura
+	end
+
 	local visible = 0
 	local hidden = 0
-
 	local index = 1
-	local unitAuraFiltered = AuraFiltered[filter][unit]
-	local auraInstanceID, aura = next(unitAuraFiltered)
-	while aura and (visible < limit) do
+	for i = 1, count, 2 do
+		if visible >= limit then break end
+
+		local auraInstanceID = temp[i]
+		local aura = temp[i+1]
+
 		local result = AuraUpdate(frame, element, unit, aura, index, offset, filter, isDebuff, visible)
 		if result == VISIBLE then
 			visible = visible + 1
@@ -262,7 +277,6 @@ local function FilterBars(frame, element, unit, filter, limit, isDebuff, offset,
 		end
 
 		index = index + 1
-		auraInstanceID, aura = next(unitAuraFiltered, auraInstanceID)
 	end
 
 	if(not dontHide) then

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
@@ -12,7 +12,10 @@ local UnitCanAssist = UnitCanAssist
 
 local function DebuffLoop(_, check, list, name, icon, _, auraType, _, _, _, _, _, spellID)
 	local allowSpell = oUF:NotSecretValue(spellID)
-	local spell = list and (allowSpell and oUF:NotSecretValue(name)) and (list[spellID] or list[name])
+	local spell
+	if list and allowSpell and oUF:NotSecretValue(name) then
+		spell = list[spellID] or list[name]
+	end
 
 	if spell then
 		if spell.enable then
@@ -31,7 +34,10 @@ local function DebuffLoop(_, check, list, name, icon, _, auraType, _, _, _, _, _
 end
 
 local function BuffLoop(_, _, list, name, icon, _, auraType, _, _, source, _, _, spellID)
-	local spell = list and (oUF:NotSecretValue(spellID) and oUF:NotSecretValue(name)) and (list[spellID] or list[name])
+	if not list then return end
+	if oUF:IsSecretValue(spellID) or oUF:IsSecretValue(name) then return end
+
+	local spell = list[spellID] or list[name]
 	if spell and spell.enable and (not spell.ownOnly or source == 'player') then
 		return auraType, icon, true, spell.style, spell.color
 	end
@@ -45,8 +51,13 @@ end
 
 local function Looper(unit, filter, check, list, func)
 	local unitAuraFiltered = AuraFiltered[filter][unit]
+	if not unitAuraFiltered then return end
+
 	local auraInstanceID, aura = next(unitAuraFiltered)
+	local checked = 0
 	while aura do
+		checked = checked + 1
+		if checked > 40 then return end
 		local name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID = oUF:UnpackAuraData(aura)
 		local AuraType, Icon, filtered, style, color = func(aura, check, list, name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID)
 

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
@@ -54,10 +54,7 @@ local function Looper(unit, filter, check, list, func)
 	if not unitAuraFiltered then return end
 
 	local auraInstanceID, aura = next(unitAuraFiltered)
-	local checked = 0
 	while aura do
-		checked = checked + 1
-		if checked > 40 then return end
 		local name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID = oUF:UnpackAuraData(aura)
 		local AuraType, Icon, filtered, style, color = func(aura, check, list, name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID)
 

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
@@ -224,10 +224,25 @@ end
 local function FilterIcons(element, unit, filter, limit, isDebuff, offset, dontHide)
 	if not offset then offset = 0 end
 
-	local index, visible, hidden = 1, 0, 0
 	local unitAuraFiltered = AuraFiltered[filter][unit]
-	local auraInstanceID, aura = next(unitAuraFiltered)
-	while aura and (visible < limit) do
+	if not unitAuraFiltered then return 0, 0 end
+
+	local temp = {}
+	local count = 0
+	for auraInstanceID, aura in next, unitAuraFiltered do
+		count = count + 1
+		temp[count] = auraInstanceID
+		count = count + 1
+		temp[count] = aura
+	end
+
+	local index, visible, hidden = 1, 0, 0
+	for i = 1, count, 2 do
+		if visible >= limit then break end
+
+		local auraInstanceID = temp[i]
+		local aura = temp[i+1]
+
 		local result = UpdateIcon(element, unit, aura, index, offset, filter, isDebuff, visible)
 		if result == VISIBLE then
 			visible = visible + 1
@@ -236,7 +251,6 @@ local function FilterIcons(element, unit, filter, limit, isDebuff, offset, dontH
 		end
 
 		index = index + 1
-		auraInstanceID, aura = next(unitAuraFiltered, auraInstanceID)
 	end
 
 	if not dontHide then


### PR DESCRIPTION
### Problem
In WoW Midnight, unit-frame values (such as GUIDs, class info, item levels, nameplate variables, etc.) can be secret or temporarily unavailable in instanced content, which led to:
1. **3D Portraits** failing to load or crashing for secret/protected target units.
2. **Aura Highlight and Range fading** crashing or timing out on nil or secret values (producing "script ran too long" errors).
3. **Pet Bar spell data callbacks** being registered repeatedly during pet updates, which could fill Blizzard's async callback system and produce a "script ran too long" error from `AsyncCallbackSystem.lua`.

### Resolution
This PR addresses all previous maintainer feedback from PR #1826 and PR #1829:

1. **Pristine stock oUF (Objection 1 Resolved)**:
   - We reverted all changes to the stock oUF library core (`ElvUI_Libraries/Game/Shared/oUF/elements/portrait.lua`), keeping the library 100% pristine and untouched.
   - Instead, we cleanly relocated all the Midnight-specific secret checks, 2D fallback textures, and asynchronous timer retries directly to the ElvUI side using oUF's standard `Override` hook inside `ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua` (`portrait.Override = UF.PortraitOverride`).
   - This keeps the stock oUF library completely stock, and houses ElvUI's internal secret checking API (`E:IsSecretValue`) cleanly within ElvUI.

2. **Optimized Aura Highlight iteration (Objection 2 Resolved)**:
   - We removed the arbitrary `checked > 40` loop count limit from `oUF_AuraHighlight.lua`. The looper now executes naturally and efficiently on the cached filtered list.

3. **Range Checks Guard**:
   - Added safety guards to `ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua` to safely handle `nil` ranges or lists when values are temporarily unavailable.

4. **Pet Bar callback guard**:
   - Pet action spell load callbacks are now registered only when a button's `spellID` changes, with stale callbacks cancelled when the spell changes, disappears, or the bar hides.