### PR TITLE
Feature: add Anchor Point option for the holder in Private Auras

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -674,7 +674,8 @@ function UF:Configure_PrivateAuras(frame)
 	if db and db.enable then
 		element:SetFrameLevel(frame.RaisedElementParent.PrivateAurasLevel)
 		element:ClearAllPoints()
-		element:Point(E.InversePoints[db.parent.point], frame, db.parent.point, db.parent.offsetX, db.parent.offsetY)
+		local holderAnchor = db.parent.anchorPoint or E.InversePoints[db.parent.point]
+		element:Point(holderAnchor, frame, db.parent.point, db.parent.offsetX, db.parent.offsetY)
 		element:Size(db.icon.size)
 
 		PA:SetupAuras(element)

--- a/ElvUI_Options/Game/Shared/UnitFrames.lua
+++ b/ElvUI_Options/Game/Shared/UnitFrames.lua
@@ -87,8 +87,9 @@ local function GetOptionsTable_PrivateAuras(updateFunc, groupName, numUnits)
 
 	config.args.parent = ACH:Group(L["Holder"], nil, 10, nil, function(info) return E.db.unitframe.units[groupName].privateAuras.parent[info[#info]] end, function(info, value) E.db.unitframe.units[groupName].privateAuras.parent[info[#info]] = value updateFunc(UF, groupName, numUnits) end)
 	config.args.parent.args.point = ACH:Select(L["Point"], nil, 5, C.Values.AllPoints)
-	config.args.parent.args.offsetX = ACH:Range(L["X-Offset"], nil, 6, offsetShort)
-	config.args.parent.args.offsetY = ACH:Range(L["Y-Offset"], nil, 7, offsetShort)
+	config.args.parent.args.anchorPoint = ACH:Select(L["Anchor Point"], L["The point on the holder that anchors to the frame. Default mirrors the frame point automatically."], 6, function() local t = E:CopyTable({}, C.Values.AllPoints) t.AUTO = L["Auto (mirror)"] return t end, nil, nil, function(info) return E.db.unitframe.units[groupName].privateAuras.parent.anchorPoint or 'AUTO' end, function(info, value) E.db.unitframe.units[groupName].privateAuras.parent.anchorPoint = (value ~= 'AUTO') and value or nil updateFunc(UF, groupName, numUnits) end)
+	config.args.parent.args.offsetX = ACH:Range(L["X-Offset"], nil, 7, offsetShort)
+	config.args.parent.args.offsetY = ACH:Range(L["Y-Offset"], nil, 8, offsetShort)
 	config.args.parent.inline = true
 
 	config.args.icon = ACH:Group(L["Icon"], nil, 20, nil, function(info) return E.db.unitframe.units[groupName].privateAuras.icon[info[#info]] end, function(info, value) E.db.unitframe.units[groupName].privateAuras.icon[info[#info]] = value updateFunc(UF, groupName, numUnits) end)


### PR DESCRIPTION
Adds an optional "Anchor Point" setting for private aura holders, letting users choose which point on the holder anchors to the frame, instead of always mirroring the frame point automatically.

Defaults to "Auto (mirror)", which preserves current behavior — no change for existing users.