### PR TITLE
Last and final fix to disppearing PAs or PAs showing on wrong frame (hopefully)

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -681,6 +681,28 @@ function UF:Configure_PrivateAuras(frame)
 	end
 end
 
+function UF:RefreshAllPrivateAuras()
+	for _, frame in pairs(UF.units) do
+		if frame.PrivateAuras then
+			UF:Configure_PrivateAuras(frame)
+		end
+	end
+
+	for _, header in pairs(UF.headers) do
+		if header.ExecuteForChildren then
+			header:ExecuteForChildren(nil, function(child)
+				if child.PrivateAuras then
+					UF:Configure_PrivateAuras(child)
+				end
+			end)
+		end
+	end
+end
+
+function UF:GROUP_ROSTER_UPDATE()
+	C_Timer.After(0, UF.RefreshAllPrivateAuras)
+end
+
 function UF:Construct_Fader()
 	return { UpdateRange = UF.UpdateRange }
 end
@@ -2254,6 +2276,7 @@ function UF:Initialize()
 	UF:UpdateColors()
 
 	UF:RegisterEvent('PLAYER_ENTERING_WORLD')
+	UF:RegisterEvent('GROUP_ROSTER_UPDATE')
 	UF:RegisterEvent('PLAYER_TARGET_CHANGED')
 	UF:RegisterEvent('PLAYER_FOCUS_CHANGED')
 	UF:RegisterEvent('SOUNDKIT_FINISHED')

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -714,10 +714,6 @@ function UF:GROUP_ROSTER_UPDATE()
 	end)
 end
 
-function UF:GROUP_ROSTER_UPDATE()
-	C_Timer.After(0, UF.RefreshAllPrivateAuras)
-end
-
 function UF:Construct_Fader()
 	return { UpdateRange = UF.UpdateRange }
 end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -690,7 +690,7 @@ function UF:RefreshAllPrivateAuras()
 	end
 end
 
-local refreshpending
+local refreshPending
 function UF:GROUP_ROSTER_UPDATE()
 	if InCombatLockdown() then return end
 	if refreshPending then return end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -682,6 +682,12 @@ function UF:Configure_PrivateAuras(frame)
 end
 
 function UF:RefreshAllPrivateAuras()
+	-- Rebuild every frame's private aura anchors against the current,
+	-- settled roster. Relying on oUF's per-frame UpdateAllElements
+	-- dispatch can miss frames whose unit assignment changed during a
+	-- leave+reinvite shuffle, leaving anchors bound to the wrong unit
+	-- (private auras showing on the wrong frame). Walking all frames
+	-- directly — like toggling the option off/on does — fixes this.
 	for _, frame in pairs(UF.units) do
 		if frame.PrivateAuras then
 			UF:Configure_PrivateAuras(frame)
@@ -2221,7 +2227,7 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-	if self.PrivateAuras and (event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD') then
+	if self.PrivateAuras and (event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD' or event == 'OnShow') then
 		UF:Configure_PrivateAuras(self)
 	end
 end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -682,25 +682,14 @@ function UF:Configure_PrivateAuras(frame)
 end
 
 function UF:RefreshAllPrivateAuras()
-	-- Equivalent to toggling enable off/on PAs for each group in /ec-unitframes.
-	-- Rebuilds each existing header, which properly refreshes private
-	-- auras after roster changes (including late-appearing follower units).
 	for groupName in pairs(UF.headers) do
 		UF:CreateAndUpdateHeaderGroup(groupName)
 	end
 end
 
-local refreshPending
 function UF:GROUP_ROSTER_UPDATE()
 	if InCombatLockdown() then return end
-	if refreshPending then return end
-	refreshPending = true
-	C_Timer.After(1, function()
-		refreshPending = false
-		if not InCombatLockdown() then
-			UF:RefreshAllPrivateAuras()
-		end
-	end)
+	UF:RefreshAllPrivateAuras()
 end
 
 function UF:Construct_Fader()

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -2227,8 +2227,17 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-	if self.PrivateAuras and (event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD' or event == 'OnShow') then
+	if not self.PrivateAuras then return end
+
+	if event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD' then
 		UF:Configure_PrivateAuras(self)
+	elseif event == 'OnShow' then
+		local frame = self
+		C_Timer.After(0, function()
+			if frame.PrivateAuras and frame.unit and UnitExists(frame.unit) then
+				UF:Configure_PrivateAuras(frame)
+			end
+		end)
 	end
 end
 

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -681,28 +681,6 @@ function UF:Configure_PrivateAuras(frame)
 	end
 end
 
-function UF:RefreshAllPrivateAuras()
-	for _, frame in pairs(UF.units) do
-		if frame.PrivateAuras then
-			UF:Configure_PrivateAuras(frame)
-		end
-	end
-
-	for _, header in pairs(UF.headers) do
-		if header.ExecuteForChildren then
-			header:ExecuteForChildren(nil, function(child)
-				if child.PrivateAuras then
-					UF:Configure_PrivateAuras(child)
-				end
-			end)
-		end
-	end
-end
-
-function UF:GROUP_ROSTER_UPDATE()
-	C_Timer.After(0, UF.RefreshAllPrivateAuras)
-end
-
 function UF:Construct_Fader()
 	return { UpdateRange = UF.UpdateRange }
 end
@@ -2276,7 +2254,6 @@ function UF:Initialize()
 	UF:UpdateColors()
 
 	UF:RegisterEvent('PLAYER_ENTERING_WORLD')
-	UF:RegisterEvent('GROUP_ROSTER_UPDATE')
 	UF:RegisterEvent('PLAYER_TARGET_CHANGED')
 	UF:RegisterEvent('PLAYER_FOCUS_CHANGED')
 	UF:RegisterEvent('SOUNDKIT_FINISHED')

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -682,35 +682,23 @@ function UF:Configure_PrivateAuras(frame)
 end
 
 function UF:RefreshAllPrivateAuras()
-	-- Walk every unit frame and reconfigure its private aura anchors.
-	-- Equivalent to what toggling the option off/on in /ec does.
-	for _, frame in pairs(UF.units) do
-		if frame.PrivateAuras then
-			UF:Configure_PrivateAuras(frame)
-		end
-	end
-
-	for _, header in pairs(UF.headers) do
-		if header.ExecuteForChildren then
-			header:ExecuteForChildren(nil, function(child)
-				if child.PrivateAuras then
-					UF:Configure_PrivateAuras(child)
-				end
-			end)
-		end
+	-- Equivalent to toggling enable off/on PAs for each group in /ec-unitframes.
+	-- Rebuilds each existing header, which properly refreshes private
+	-- auras after roster changes (including late-appearing follower units).
+	for groupName in pairs(UF.headers) do
+		UF:CreateAndUpdateHeaderGroup(groupName)
 	end
 end
 
-local refreshPending
 function UF:GROUP_ROSTER_UPDATE()
-	-- Coalesce bursts of roster events into a single deferred refresh.
-	-- Wait long enough for late-appearing units to register (e.g.
-	-- followers in follower raids appear a few seconds after zone-in).
+	if InCombatLockdown() then return end
 	if refreshPending then return end
 	refreshPending = true
-	C_Timer.After(2, function()
+	C_Timer.After(1, function()
 		refreshPending = false
-		UF:RefreshAllPrivateAuras()
+		if not InCombatLockdown() then
+			UF:RefreshAllPrivateAuras()
+		end
 	end)
 end
 

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -690,6 +690,7 @@ function UF:RefreshAllPrivateAuras()
 	end
 end
 
+local refreshpending
 function UF:GROUP_ROSTER_UPDATE()
 	if InCombatLockdown() then return end
 	if refreshPending then return end

--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -682,12 +682,8 @@ function UF:Configure_PrivateAuras(frame)
 end
 
 function UF:RefreshAllPrivateAuras()
-	-- Rebuild every frame's private aura anchors against the current,
-	-- settled roster. Relying on oUF's per-frame UpdateAllElements
-	-- dispatch can miss frames whose unit assignment changed during a
-	-- leave+reinvite shuffle, leaving anchors bound to the wrong unit
-	-- (private auras showing on the wrong frame). Walking all frames
-	-- directly — like toggling the option off/on does — fixes this.
+	-- Walk every unit frame and reconfigure its private aura anchors.
+	-- Equivalent to what toggling the option off/on in /ec does.
 	for _, frame in pairs(UF.units) do
 		if frame.PrivateAuras then
 			UF:Configure_PrivateAuras(frame)
@@ -703,6 +699,19 @@ function UF:RefreshAllPrivateAuras()
 			end)
 		end
 	end
+end
+
+local refreshPending
+function UF:GROUP_ROSTER_UPDATE()
+	-- Coalesce bursts of roster events into a single deferred refresh.
+	-- Wait long enough for late-appearing units to register (e.g.
+	-- followers in follower raids appear a few seconds after zone-in).
+	if refreshPending then return end
+	refreshPending = true
+	C_Timer.After(2, function()
+		refreshPending = false
+		UF:RefreshAllPrivateAuras()
+	end)
 end
 
 function UF:GROUP_ROSTER_UPDATE()
@@ -2227,17 +2236,8 @@ do -- Clique support for registering clicks
 end
 
 function UF:UpdateAllElements(event)
-	if not self.PrivateAuras then return end
-
-	if event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD' then
+	if self.PrivateAuras and (event == 'GROUP_ROSTER_UPDATE' or event == 'PLAYER_ENTERING_WORLD') then
 		UF:Configure_PrivateAuras(self)
-	elseif event == 'OnShow' then
-		local frame = self
-		C_Timer.After(0, function()
-			if frame.PrivateAuras and frame.unit and UnitExists(frame.unit) then
-				UF:Configure_PrivateAuras(frame)
-			end
-		end)
 	end
 end
 


### PR DESCRIPTION
Private auras disappear/show on wrong party/raid frame from many weird interactions like: 
- A raid member leaving the raid mid combat then the PA will go stale and show on wrong frame 
- Since the OnShow event was removed testing in a follower raid didn't show any PA or PA on the player was replicated to all frames, since follower frames populate a few seconds later after loading in the raid. 

To work around this i had to manually toggle PAs off/on under `/ec - UnitFrames - Party/Raid - Private Auras`, after joining a new raid/party or when someone leaves/joins the raid after a wipe which rebuilds the headers.

This fix automates that toggle on `GROUP_ROSTER_UPDATE`:
- Walks `UF.headers` and calls `CreateAndUpdateHeaderGroup` on each, equivalent to the manual toggle.
- Skips while in combat lockdown to avoid `ADDON_ACTION_BLOCKED` from secure frame access.

Tested in mythic raid (leave/reinvite scenario), M+ dungeons, and follower raid. All cases now bind PAs to the correct frame without manual intervention. 

Looks promising after testing it for 2 days probably need more testing from you to confirm

only last comit matter