### PR TITLE
last and final fix to disappearing PAs/showing on wrong frame (hopefully)

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -681,6 +681,17 @@ function UF:Configure_PrivateAuras(frame)
 	end
 end
 
+function UF:RefreshAllPrivateAuras()
+	for groupName in pairs(UF.headers) do
+		UF:CreateAndUpdateHeaderGroup(groupName)
+	end
+end
+
+function UF:GROUP_ROSTER_UPDATE()
+	if InCombatLockdown() then return end
+	UF:RefreshAllPrivateAuras()
+end
+
 function UF:Construct_Fader()
 	return { UpdateRange = UF.UpdateRange }
 end
@@ -2254,6 +2265,7 @@ function UF:Initialize()
 	UF:UpdateColors()
 
 	UF:RegisterEvent('PLAYER_ENTERING_WORLD')
+	UF:RegisterEvent('GROUP_ROSTER_UPDATE')
 	UF:RegisterEvent('PLAYER_TARGET_CHANGED')
 	UF:RegisterEvent('PLAYER_FOCUS_CHANGED')
 	UF:RegisterEvent('SOUNDKIT_FINISHED')


### PR DESCRIPTION
Private auras disappear/show on wrong party/raid frame from many weird interactions like: 
- A raid member leaving the raid mid combat then the PA will go stale and show on wrong frame 
- Since the OnShow event was removed testing in a follower raid didn't show any PA or PA on the player was replicated to all frames, since follower frames populate a few seconds later after loading in the raid. 

To work around this i had to manually toggle PAs off/on under `/ec - UnitFrames - Party/Raid - Private Auras`, after joining a new raid/party or when someone leaves/joins the raid after a wipe which rebuilds the headers.

This fix automates that toggle on `GROUP_ROSTER_UPDATE`:
- Walks `UF.headers` and calls `CreateAndUpdateHeaderGroup` on each, equivalent to the manual toggle.
- Skips while in combat lockdown to avoid `ADDON_ACTION_BLOCKED` from secure frame access.

Tested in mythic raid (leave/reinvite scenario), M+ dungeons, and follower raid. All cases now bind PAs to the correct frame without manual intervention. 

Looks promising after testing it for 2 days probably need more testing from you to confirm