### PR TITLE
fix tooltip widget set taint

### DIFF
--- a/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
+++ b/ElvUI/Game/Shared/Modules/Tooltip/Tooltip.lua
@@ -60,6 +60,7 @@ local UnitReaction = UnitReaction
 local UnitRealmRelationship = UnitRealmRelationship
 local UnitTokenFromGUID = UnitTokenFromGUID
 local UnitSex = UnitSex
+local securecallfunction = securecallfunction
 
 local TooltipDataType = Enum.TooltipDataType
 local ScaleTo100 = CurveConstants and CurveConstants.ScaleTo100
@@ -1185,6 +1186,13 @@ function TT:Initialize()
 
 	TT:SetTooltipFonts()
 	TT:SetStatusBarFont()
+
+	if E.Retail and _G.GameTooltip_AddWidgetSet and not _G.ElvUI_TaintFix_GameTooltip_AddWidgetSet then
+		_G.ElvUI_TaintFix_GameTooltip_AddWidgetSet = _G.GameTooltip_AddWidgetSet
+		_G.GameTooltip_AddWidgetSet = function(...)
+			return securecallfunction(_G.ElvUI_TaintFix_GameTooltip_AddWidgetSet, ...)
+		end
+	end
 
 	local TooltipAnchor = CreateFrame('Frame', 'ElvUI_TooltipAnchor', E.UIParent)
 	if TooltipAnchor then


### PR DESCRIPTION
## What changed

Wrap Retail `GameTooltip_AddWidgetSet` so ElvUI calls Blizzards original implementation through `securecallfunction`.

## Why

Some tooltip widget sets can expose secret values while Blizzard lays out UI widgets. When `GameTooltip_AddWidgetSet` runs in an ElvUI-tainted execution path, Blizzard code can crash while doing arithmetic on those secret values, for example:

```
Blizzard_UIWidgetTemplateTextWithState.lua:35: attempt to perform arithmetic on local `textHeight` (a secret number value, while execution tainted by `ElvUI`)
```

Calling the original Blizzard function through `securecallfunction` avoids carrying ElvUI taint into the widget processing path, without suppressing any widget set or hiding tooltip content.

## Reproduction observed

- Retail
- Hovering an Area POI story variant tooltip with widgetSetID `1273`
- Stack path: `GameTooltip_AddWidgetSet` -> `UIWidgetManager:RegisterForWidgetSet` -> `TextWithStateWidget:Setup`

## Validation

- `git diff --check`
- Applied locally and intended for in-game verification with `/reload` plus the affected Area POI hover path
