### PR TITLE
feat: skin menu arrows

### DIFF
--- a/ElvUI/Game/Mainline/Skins/Menu.lua
+++ b/ElvUI/Game/Mainline/Skins/Menu.lua
@@ -26,6 +26,23 @@ local function SkinFrame(frame)
 	end
 end
 
+local function SkinFrameAttachments(frame)
+	if not frame.attachments then return end
+	local r, g, b = unpack(E.media.rgbvaluecolor)
+
+	for _, widget in ipairs(frame.attachments) do
+		local widgetType = widget:GetObjectType()
+		if widgetType == 'Texture' then
+			if widget:GetTexture() == 130940 then
+				widget:SetTexture(E.Media.Textures.ArrowUp)
+				widget:SetVertexColor(r, g, b, 1)
+				widget:SetRotation(S.ArrowRotation.right)
+				widget:Size(12)
+			end
+		end
+	end
+end
+
 function S:SkinMenu(manager, ownerRegion, menuDescription, anchor)
 	local menu = manager:GetOpenMenu()
 	if not menu then return end
@@ -50,6 +67,8 @@ function S:Blizzard_Menu()
 		hooksecurefunc(manager, 'OpenMenu', S.OpenMenu)
 		hooksecurefunc(manager, 'OpenContextMenu', S.OpenContextMenu)
 	end
+
+	hooksecurefunc(CompositorMixin, 'AttachTexture', SkinFrameAttachments)
 end
 
 S:AddCallbackForAddon('Blizzard_Menu')


### PR DESCRIPTION
This restores the class colored menu arrows.
<img width="179" height="352" alt="603873843-b07df6ad-137d-4f3b-9eea-2c98958542c6" src="https://github.com/user-attachments/assets/e83c8c77-a199-48ff-8af5-298833c552f6" />