### PR TITLE
feat: 2D portrait fallback when the 3D model isn't loaded (12.0)

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -9,6 +9,115 @@ local UnitClass = UnitClass
 
 local classIcon = [[Interface\WorldStateFrame\Icons-Classes]]
 
+local UnitGUID = UnitGUID
+local UnitIsPlayer = UnitIsPlayer
+local UnitIsVisible = UnitIsVisible
+local UnitIsConnected = UnitIsConnected
+local SetPortraitTexture = SetPortraitTexture
+local IsUnitModelReadyForUI = IsUnitModelReadyForUI
+
+local function HidePortraitFallback(element)
+	if element.Fallback2DFrame then
+		element.Fallback2DFrame:Hide()
+	end
+	if element.Fallback2D then
+		element.Fallback2D:Hide()
+	end
+
+	element.secretRetryUnit = nil
+	element.secretRetryCount = nil
+end
+
+local function HasPortraitModel(element)
+	return not element.GetModelFileID or element:GetModelFileID()
+end
+
+local function HidePortraitFallbackIfLoaded(element)
+	if element.hasSecretUnit then return false end -- handled by OnModelLoadedCheck
+	if HasPortraitModel(element) then
+		HidePortraitFallback(element)
+		return true
+	end
+end
+
+-- Fired by OnModelLoaded. For secret-GUID units, only hide the 2D cover when a
+-- DIFFERENT model file has loaded — that means the real NPC 3D model streamed in.
+-- A same-ID fire means the stale cached model was re-applied; keep the 2D cover.
+local function OnModelLoadedCheck(element)
+	if element.hasSecretUnit then
+		local newID = element:GetModelFileID()
+		if newID and newID ~= element.secretPreloadModelID then
+			HidePortraitFallback(element)
+		end
+	else
+		HidePortraitFallback(element)
+	end
+end
+
+local function RetryPortraitModel(element, unit)
+	if not C_Timer then return end
+	if element.modelRetryUnit == unit then return end
+
+	element.modelRetryUnit = unit
+	element.modelRetryCount = 0
+
+	local function retry()
+		if element.modelRetryUnit ~= unit or not element:IsShown() then return end
+		if HidePortraitFallbackIfLoaded(element) then
+			element.modelRetryUnit = nil
+			element.modelRetryCount = nil
+			return
+		end
+
+		local retryCount = (element.modelRetryCount or 0) + 1
+		element.modelRetryCount = retryCount
+		element:ClearModel()
+		element:SetUnit(unit)
+		if HidePortraitFallbackIfLoaded(element) then
+			element.modelRetryUnit = nil
+			element.modelRetryCount = nil
+			return
+		end
+
+		if element.modelRetryUnit == unit and retryCount < 10 then
+			C_Timer.After(0.25 * retryCount, retry)
+		end
+	end
+
+	C_Timer.After(0.1, retry)
+end
+
+local function RetrySecretPortrait(element, unit)
+	if not C_Timer then return end
+	if element.secretRetryUnit == unit then return end
+
+	element.secretRetryUnit = unit
+	element.secretRetryCount = 0
+
+	local function retry()
+		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
+
+		local retryCount = (element.secretRetryCount or 0) + 1
+		element.secretRetryCount = retryCount
+		element:SetUnit(unit)
+
+		if element.secretRetryUnit == unit and retryCount < 4 then
+			C_Timer.After(0.2 * retryCount, retry)
+		end
+	end
+
+	C_Timer.After(0.1, retry)
+end
+
+function UF.PortraitForceUpdate(frame, event, unit)
+	if unit == frame.unit then
+		local element = frame.Portrait
+		if element and element.ForceUpdate then
+			element:ForceUpdate()
+		end
+	end
+end
+
 function UF:ModelAlphaFix(value)
 	local portrait = self.Portrait3D
 	if not portrait then return end
@@ -17,6 +126,136 @@ function UF:ModelAlphaFix(value)
 	local modelAlpha = value * (E:IsSecretValue(alpha) and 1 or alpha)
 	portrait:SetModelAlpha(modelAlpha)
 	portrait.backdrop:SetAlpha(modelAlpha)
+end
+
+function UF:PortraitOverride(event)
+	local element = self.Portrait
+	if not element then return end
+	element.elvPortraitPatch = 1
+
+	local unit = self.unit
+	if not unit then return end
+
+	local guid = UnitGUID(unit)
+	local secretGUID = E:IsSecretValue(guid)
+	element.hasSecretUnit = secretGUID
+	local storedGUID = element.guid
+	local secretStoredGUID = E:IsSecretValue(storedGUID)
+	local newGUID = secretGUID or secretStoredGUID or (storedGUID ~= guid)
+
+	local nameplate = event == 'NAME_PLATE_UNIT_ADDED'
+	if newGUID then
+		element.secretRetryUnit = nil
+		element.secretRetryCount = nil
+		element.modelRetryUnit = nil
+		element.modelRetryCount = nil
+		element.guid = not secretGUID and guid or nil
+	elseif nameplate then
+		return
+	end
+
+	if element.PreUpdate then element:PreUpdate(unit) end
+
+	local isPlayerRaw = UnitIsPlayer(unit)
+	local isPlayer = (isPlayerRaw == true)
+	local isSecret = E:IsSecretValue(isPlayerRaw)
+	local isVisibleRaw = UnitIsVisible(unit)
+	local isVisible = not isPlayer or E:IsSecretValue(isVisibleRaw) or (isVisibleRaw == true)
+	local isConnectedRaw = UnitIsConnected(unit)
+	local isConnected = E:IsSecretValue(isConnectedRaw) or (isConnectedRaw == true)
+	local isModelReady = IsUnitModelReadyForUI and IsUnitModelReadyForUI(unit)
+	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (isModelReady and isConnected))
+	local playerModel = element:IsObjectType('PlayerModel')
+	local needsModel = playerModel and isAvailable and not HasPortraitModel(element)
+
+	local hasStateChanged = newGUID or needsModel or (not nameplate or element.state ~= isAvailable)
+	if hasStateChanged then
+		element.playerModel = playerModel
+		local prevState = element.state
+		element.state = isAvailable
+
+		if element.playerModel then
+			if not element.modelLoadedHooked then
+				element.modelLoadedHooked = true
+				pcall(element.HookScript, element, "OnModelLoaded", OnModelLoadedCheck)
+			end
+
+			if isAvailable then
+				if element.Fallback2D and HidePortraitFallbackIfLoaded(element) then
+					element.modelRetryUnit = nil
+					element.modelRetryCount = nil
+				end
+
+				element:SetCamDistanceScale(1)
+				element:SetPortraitZoom(1)
+				element:SetPosition(0, 0, 0)
+
+				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
+				-- For secret-GUID units, needsModel and newGUID are always truthy
+				-- (secret values can't be compared), so exclude them to avoid OnUpdate loops.
+				local needsLoad = (not secretGUID and needsModel) or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				if needsLoad then
+					if secretGUID then
+						-- Show a 2D cover frame immediately so any stale cached 3D model
+						-- (from the previous target) is hidden while we try to load the real
+						-- NPC model. The cover is a child Frame placed above the PlayerModel,
+						-- so it renders on top of any 3D content regardless of draw layers.
+						-- SetUnit is called WITHOUT ClearModel so the old model stays as an
+						-- invisible placeholder; if the NPC's actual model streams in,
+						-- OnModelLoadedCheck detects the new file ID and hides the cover.
+						if not element.Fallback2DFrame then
+							local cover = CreateFrame("Frame", nil, element)
+							cover:SetAllPoints(element)
+							local tex = cover:CreateTexture(nil, "BACKGROUND")
+							tex:SetAllPoints(cover)
+							tex:SetTexCoord(0.15, 0.85, 0.15, 0.85)
+							element.Fallback2D = tex
+							element.Fallback2DFrame = cover
+						end
+						element.Fallback2DFrame:SetFrameLevel(element:GetFrameLevel() + 5)
+						SetPortraitTexture(element.Fallback2D, unit)
+						element.Fallback2DFrame:Show()
+						element.Fallback2D:Show()
+
+						-- Snapshot the current model ID before SetUnit so OnModelLoadedCheck
+						-- can tell a real new NPC load from a stale cache hit.
+						element.secretPreloadModelID = element:GetModelFileID()
+						element:SetUnit(unit)
+					else
+						HidePortraitFallback(element)
+						element:SetUnit(unit)
+
+						if HidePortraitFallbackIfLoaded(element) then
+							element.modelRetryUnit = nil
+							element.modelRetryCount = nil
+						else
+							RetryPortraitModel(element, unit)
+						end
+					end
+				end
+			else
+				HidePortraitFallback(element)
+				element.modelRetryUnit = nil
+				element.modelRetryCount = nil
+				element:ClearModel()
+				element:SetCamDistanceScale(0.25)
+				element:SetPortraitZoom(0)
+				element:SetPosition(0, 0, 0.25)
+				element:SetModel([[Interface\Buttons\TalkToMeQuestionMark.m2]])
+			end
+		elseif element.useClassBase then
+			local _, className = UnitClass(unit)
+			if className then
+				element:SetAtlas('classicon-' .. className)
+			end
+		elseif not element.customTexture then
+			SetPortraitTexture(element, unit)
+		end
+	end
+
+	if element.PostUpdate then
+		return element:PostUpdate(unit, hasStateChanged)
+	end
 end
 
 function UF:Construct_Portrait(frame, which)
@@ -43,6 +282,7 @@ function UF:Construct_Portrait(frame, which)
 
 	portrait.__owner = frame -- set this for both, oUF will only set it when active
 	portrait.PostUpdate = UF.PortraitUpdate
+	portrait.Override = UF.PortraitOverride
 
 	return portrait
 end
@@ -76,8 +316,10 @@ function UF:Configure_Portrait(frame)
 
 		if portrait.db.style == '3D' then
 			portrait:OffsetFrameLevel(nil, frame.Health)
+			frame:RegisterEvent('UNIT_PORTRAIT_UPDATE', UF.PortraitForceUpdate)
 		else
 			portrait:SetParent(frame.USE_PORTRAIT_OVERLAY and frame.Health or frame)
+			frame:UnregisterEvent('UNIT_PORTRAIT_UPDATE', UF.PortraitForceUpdate)
 		end
 
 		portrait:ClearAllPoints()
@@ -141,6 +383,7 @@ function UF:Configure_Portrait(frame)
 		end
 	elseif frame:IsElementEnabled('Portrait') then
 		frame:DisableElement('Portrait')
+		frame:UnregisterEvent('UNIT_PORTRAIT_UPDATE', UF.PortraitForceUpdate)
 	end
 end
 

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -23,9 +23,6 @@ local function HidePortraitFallback(element)
 	if element.Fallback2D then
 		element.Fallback2D:Hide()
 	end
-
-	element.secretRetryUnit = nil
-	element.secretRetryCount = nil
 end
 
 local function HasPortraitModel(element)
@@ -40,18 +37,11 @@ local function HidePortraitFallbackIfLoaded(element)
 	end
 end
 
--- Fired by OnModelLoaded. For secret-GUID units, only hide the 2D cover when a
--- DIFFERENT model file has loaded — that means the real NPC 3D model streamed in.
--- A same-ID fire means the stale cached model was re-applied; keep the 2D cover.
+-- A secret-identity unit cannot be passed to PlayerModel:SetUnit on 12.0.5+.
+-- Ignore stale model callbacks for it and keep the supported 2D cover visible.
 local function OnModelLoadedCheck(element)
-	if element.hasSecretUnit then
-		local newID = element:GetModelFileID()
-		if newID and newID ~= element.secretPreloadModelID then
-			HidePortraitFallback(element)
-		end
-	else
-		HidePortraitFallback(element)
-	end
+	if element.hasSecretUnit then return end
+	HidePortraitFallback(element)
 end
 
 local function RetryPortraitModel(element, unit)
@@ -62,7 +52,12 @@ local function RetryPortraitModel(element, unit)
 	element.modelRetryCount = 0
 
 	local function retry()
-		if element.modelRetryUnit ~= unit or not element:IsShown() then return end
+		if element.modelRetryUnit ~= unit then return end
+		if not element:IsShown() then
+			element.modelRetryUnit = nil
+			element.modelRetryCount = nil
+			return
+		end
 		if HidePortraitFallbackIfLoaded(element) then
 			element.modelRetryUnit = nil
 			element.modelRetryCount = nil
@@ -81,28 +76,6 @@ local function RetryPortraitModel(element, unit)
 
 		if element.modelRetryUnit == unit and retryCount < 10 then
 			C_Timer.After(0.25 * retryCount, retry)
-		end
-	end
-
-	C_Timer.After(0.1, retry)
-end
-
-local function RetrySecretPortrait(element, unit)
-	if not C_Timer then return end
-	if element.secretRetryUnit == unit then return end
-
-	element.secretRetryUnit = unit
-	element.secretRetryCount = 0
-
-	local function retry()
-		if element.secretRetryUnit ~= unit or not element:IsShown() then return end
-
-		local retryCount = (element.secretRetryCount or 0) + 1
-		element.secretRetryCount = retryCount
-		element:SetUnit(unit)
-
-		if element.secretRetryUnit == unit and retryCount < 4 then
-			C_Timer.After(0.2 * retryCount, retry)
 		end
 	end
 
@@ -145,8 +118,6 @@ function UF:PortraitOverride(event)
 
 	local nameplate = event == 'NAME_PLATE_UNIT_ADDED'
 	if newGUID then
-		element.secretRetryUnit = nil
-		element.secretRetryCount = nil
 		element.modelRetryUnit = nil
 		element.modelRetryCount = nil
 		element.guid = not secretGUID and guid or nil
@@ -157,14 +128,15 @@ function UF:PortraitOverride(event)
 	if element.PreUpdate then element:PreUpdate(unit) end
 
 	local isPlayerRaw = UnitIsPlayer(unit)
-	local isPlayer = (isPlayerRaw == true)
-	local isSecret = E:IsSecretValue(isPlayerRaw)
+	local isPlayerSecret = E:IsSecretValue(isPlayerRaw)
+	local isPlayer = not isPlayerSecret and isPlayerRaw == true
 	local isVisibleRaw = UnitIsVisible(unit)
 	local isVisible = not isPlayer or E:IsSecretValue(isVisibleRaw) or (isVisibleRaw == true)
 	local isConnectedRaw = UnitIsConnected(unit)
 	local isConnected = E:IsSecretValue(isConnectedRaw) or (isConnectedRaw == true)
-	local isModelReady = IsUnitModelReadyForUI and IsUnitModelReadyForUI(unit)
-	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isSecret or (isModelReady and isConnected))
+	local isModelReadyRaw = IsUnitModelReadyForUI and IsUnitModelReadyForUI(unit)
+	local isModelReady = E:IsSecretValue(isModelReadyRaw) or isModelReadyRaw == true
+	local isAvailable = element:IsVisible() and isVisible and (not isPlayer or isPlayerSecret or (isModelReady and isConnected))
 	local playerModel = element:IsObjectType('PlayerModel')
 	local needsModel = playerModel and isAvailable and not HasPortraitModel(element)
 
@@ -196,13 +168,8 @@ function UF:PortraitOverride(event)
 				local needsLoad = (not secretGUID and needsModel) or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
 				if needsLoad then
 					if secretGUID then
-						-- Show a 2D cover frame immediately so any stale cached 3D model
-						-- (from the previous target) is hidden while we try to load the real
-						-- NPC model. The cover is a child Frame placed above the PlayerModel,
-						-- so it renders on top of any 3D content regardless of draw layers.
-						-- SetUnit is called WITHOUT ClearModel so the old model stays as an
-						-- invisible placeholder; if the NPC's actual model streams in,
-						-- OnModelLoadedCheck detects the new file ID and hides the cover.
+						-- PlayerModel:SetUnit rejects secret identities on 12.0.5+.
+						-- Cover any stale 3D model with the supported 2D portrait.
 						if not element.Fallback2DFrame then
 							local cover = CreateFrame("Frame", nil, element)
 							cover:SetAllPoints(element)
@@ -216,11 +183,6 @@ function UF:PortraitOverride(event)
 						SetPortraitTexture(element.Fallback2D, unit)
 						element.Fallback2DFrame:Show()
 						element.Fallback2D:Show()
-
-						-- Snapshot the current model ID before SetUnit so OnModelLoadedCheck
-						-- can tell a real new NPC load from a stale cache hit.
-						element.secretPreloadModelID = element:GetModelFileID()
-						element:SetUnit(unit)
 					else
 						HidePortraitFallback(element)
 						element:SetUnit(unit)

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Portrait.lua
@@ -85,8 +85,8 @@ end
 function UF.PortraitForceUpdate(frame, event, unit)
 	if unit == frame.unit then
 		local element = frame.Portrait
-		if element and element.ForceUpdate then
-			element:ForceUpdate()
+		if element and element.Override then
+			element.Override(frame, event, unit)
 		end
 	end
 end
@@ -163,9 +163,10 @@ function UF:PortraitOverride(event)
 				element:SetPosition(0, 0, 0)
 
 				local noUnitChange = event == "UNIT_PORTRAIT_UPDATE" or event == "UNIT_CONNECTION" or event == "PARTY_MEMBER_ENABLE" or event == "PARTY_MEMBER_DISABLE" or event == "UNIT_MODEL_CHANGED" or event == "OnUpdate"
-				-- For secret-GUID units, needsModel and newGUID are always truthy
-				-- (secret values can't be compared), so exclude them to avoid OnUpdate loops.
-				local needsLoad = (not secretGUID and needsModel) or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and not noUnitChange)
+				-- Secret GUIDs cannot be compared, so only refresh them for real events or
+				-- eventless frames whose nested unit (such as targettarget) may have changed.
+				local eventlessRefresh = event == "OnUpdate" and self.__eventless
+				local needsLoad = (not secretGUID and needsModel) or (not secretGUID and newGUID) or (not secretGUID and event == "UNIT_MODEL_CHANGED") or (not prevState) or (event == "OnShow") or (secretGUID and (event == "UNIT_PORTRAIT_UPDATE" or eventlessRefresh or not noUnitChange))
 				if needsLoad then
 					if secretGUID then
 						-- PlayerModel:SetUnit rejects secret identities on 12.0.5+.


### PR DESCRIPTION
## Summary

Adds a 2D portrait fallback for unit-frame portraits whose 3D model cannot be loaded on Midnight, and keeps that fallback synchronized for nested eventless units such as `targettarget`.

In instanced content, non-group unit identities can be secret. Since 12.0.5, `PlayerModel:SetUnit` rejects those unit tokens with `RequiresDeclassifiedIdentity`, so retrying the 3D load cannot succeed and can leave a stale model from the previous unit visible.

## What the patch does

The portrait update is implemented through `Portrait.Override`, leaving the bundled oUF portrait element untouched.

- Checks secret GUIDs and secret boolean results before comparing or branching on them.
- Places a supported 2D portrait texture in a cover frame above the `PlayerModel` when the unit identity is secret. This hides any stale 3D model without calling the rejected `SetUnit` API.
- Preserves normal 3D portraits and bounded asynchronous model retries for non-secret units.
- Clears retry state when the model is hidden or the represented unit changes.
- Preserves the original `UNIT_PORTRAIT_UPDATE` event when forwarding it to the override, allowing the 2D fallback to refresh to the current unit.
- Refreshes secret portraits during the normal polling of eventless nested frames such as `targettarget`. These frames do not receive a reliable identity-change event, and secret GUIDs cannot be compared, so polling is the only supported way to keep their 2D texture current.

## Resulting behavior

- A secret target uses a current 2D portrait instead of a stale or repeatedly retried 3D model.
- `targettarget` and other eventless nested portraits update when the nested unit changes, rather than retaining the first fallback texture they displayed.
- Units whose identities are accessible continue to use 3D portraits.
- A nested unit reached through a secret identity may still require the 2D fallback even when it ultimately represents the player. Blizzard also protects `UnitIsUnit` and `UnitGUID` for that derived token, and `PlayerModel:SetUnit("targettarget")` fails with `RequiresDeclassifiedIdentity`; the addon cannot safely map it back to `player`.

## Validation

- Tested in instanced content with ungrouped NPC targets: the fallback displays without the previous model-retry lag.
- Tested repeated `targettarget` changes: the fallback texture follows the current target-of-target instead of keeping the first one.
- Confirmed that trying to load the protected nested token directly is rejected by Blizzard with `RequiresDeclassifiedIdentity`.
- `git diff --check` passes.

## Limitation

A 3D model cannot be recovered through the public API while the unit token has a secret identity. The 2D portrait remains the supported fallback until Blizzard declassifies that identity.
