### PR TITLE
fix: nil-safe aura/range iteration + pet spell-load caching (12.0)

### DIFF
--- a/ElvUI/Game/Shared/Modules/ActionBars/PetBar.lua
+++ b/ElvUI/Game/Shared/Modules/ActionBars/PetBar.lua
@@ -28,6 +28,16 @@ local bar = CreateFrame('Frame', 'ElvUI_BarPet', E.UIParent, 'SecureHandlerState
 bar:SetFrameStrata('LOW')
 bar.buttons = {}
 
+local function ClearPetButtonSpellData(button)
+	if button.spellDataLoadedCancelFunc then
+		button.spellDataLoadedCancelFunc()
+		button.spellDataLoadedCancelFunc = nil
+	end
+
+	button.spellDataLoadedSpellID = nil
+	button.tooltipSubtext = nil
+end
+
 function AB:UpdatePet(event, unit)
 	if (event == 'UNIT_FLAGS' and unit ~= 'pet') or (event == 'UNIT_PET' and unit ~= 'player') then return end
 
@@ -54,11 +64,23 @@ function AB:UpdatePet(event, unit)
 			button.tooltipName = _G[name]
 		end
 
-		if spellID then
+		if spellID and button.spellDataLoadedSpellID ~= spellID then
+			ClearPetButtonSpellData(button)
+			button.spellDataLoadedSpellID = spellID
+
 			local spell = _G.Spell:CreateFromSpellID(spellID)
-			button.spellDataLoadedCancelFunc = spell:ContinueWithCancelOnSpellLoad(function()
-				button.tooltipSubtext = spell:GetSpellSubtext()
+			local spellDataLoaded
+			local cancelFunc = spell:ContinueWithCancelOnSpellLoad(function()
+				if button.spellDataLoadedSpellID == spellID then
+					button.tooltipSubtext = spell:GetSpellSubtext()
+					button.spellDataLoadedCancelFunc = nil
+				end
+
+				spellDataLoaded = true
 			end)
+			button.spellDataLoadedCancelFunc = not spellDataLoaded and cancelFunc or nil
+		elseif not spellID and button.spellDataLoadedSpellID then
+			ClearPetButtonSpellData(button)
 		end
 
 		if isActive and name ~= 'PET_ACTION_FOLLOW' then
@@ -227,10 +249,7 @@ end
 
 function AB:PetBar_OnHide()
 	for _, button in ipairs(bar.buttons) do
-		if button.spellDataLoadedCancelFunc then
-			button.spellDataLoadedCancelFunc()
-			button.spellDataLoadedCancelFunc = nil
-		end
+		ClearPetButtonSpellData(button)
 	end
 end
 

--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Range.lua
@@ -26,6 +26,8 @@ local list = {}
 UF.RangeSpells = list
 
 function UF:UpdateRangeList(db)
+	if not db then return {} end
+
 	local spells = {}
 	for spell, value in next, db do
 		if value then
@@ -78,6 +80,8 @@ end
 
 function UF:UnitInSpellsRange(unit, which)
 	local spells = list[which]
+	if not spells then return nil end
+
 	local range = (not next(spells) and 1) or UF:UnitSpellRange(unit, spells)
 
 	if (not range or range == 1) and not InCombatLockdown() then

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraBars.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraBars.lua
@@ -247,13 +247,28 @@ end
 
 local function FilterBars(frame, element, unit, filter, limit, isDebuff, offset, dontHide)
 	if(not offset) then offset = 0 end
+
+	local unitAuraFiltered = AuraFiltered[filter][unit]
+	if not unitAuraFiltered then return 0, 0 end
+
+	local temp = {}
+	local count = 0
+	for auraInstanceID, aura in next, unitAuraFiltered do
+		count = count + 1
+		temp[count] = auraInstanceID
+		count = count + 1
+		temp[count] = aura
+	end
+
 	local visible = 0
 	local hidden = 0
-
 	local index = 1
-	local unitAuraFiltered = AuraFiltered[filter][unit]
-	local auraInstanceID, aura = next(unitAuraFiltered)
-	while aura and (visible < limit) do
+	for i = 1, count, 2 do
+		if visible >= limit then break end
+
+		local auraInstanceID = temp[i]
+		local aura = temp[i+1]
+
 		local result = AuraUpdate(frame, element, unit, aura, index, offset, filter, isDebuff, visible)
 		if result == VISIBLE then
 			visible = visible + 1
@@ -262,7 +277,6 @@ local function FilterBars(frame, element, unit, filter, limit, isDebuff, offset,
 		end
 
 		index = index + 1
-		auraInstanceID, aura = next(unitAuraFiltered, auraInstanceID)
 	end
 
 	if(not dontHide) then

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraHighlight.lua
@@ -45,6 +45,8 @@ end
 
 local function Looper(unit, filter, check, list, func)
 	local unitAuraFiltered = AuraFiltered[filter][unit]
+	if not unitAuraFiltered then return end -- next(nil) would error
+
 	local auraInstanceID, aura = next(unitAuraFiltered)
 	while aura do
 		local name, icon, count, auraType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID = oUF:UnpackAuraData(aura)

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
@@ -224,10 +224,25 @@ end
 local function FilterIcons(element, unit, filter, limit, isDebuff, offset, dontHide)
 	if not offset then offset = 0 end
 
-	local index, visible, hidden = 1, 0, 0
 	local unitAuraFiltered = AuraFiltered[filter][unit]
-	local auraInstanceID, aura = next(unitAuraFiltered)
-	while aura and (visible < limit) do
+	if not unitAuraFiltered then return 0, 0 end
+
+	local temp = {}
+	local count = 0
+	for auraInstanceID, aura in next, unitAuraFiltered do
+		count = count + 1
+		temp[count] = auraInstanceID
+		count = count + 1
+		temp[count] = aura
+	end
+
+	local index, visible, hidden = 1, 0, 0
+	for i = 1, count, 2 do
+		if visible >= limit then break end
+
+		local auraInstanceID = temp[i]
+		local aura = temp[i+1]
+
 		local result = UpdateIcon(element, unit, aura, index, offset, filter, isDebuff, visible)
 		if result == VISIBLE then
 			visible = visible + 1
@@ -236,7 +251,6 @@ local function FilterIcons(element, unit, filter, limit, isDebuff, offset, dontH
 		end
 
 		index = index + 1
-		auraInstanceID, aura = next(unitAuraFiltered, auraInstanceID)
 	end
 
 	if not dontHide then


### PR DESCRIPTION
## Summary

Defensive nil-guards and iteration safety for unit-frame aura/range code paths that can error in 12.0 (and generally). Split out from a larger bundle so each fix is reviewable on its own. Carries over the remaining fixes from #1830 rebased on current `main`.

### `UnitFrames/Elements/Range.lua`
`UpdateRangeList(db)` can be called with a nil `db`, and `UnitInSpellsRange` reads `list[which]` which may be nil before the list is built — both then index/iterate nil. Return early.

### `ActionBars/PetBar.lua`
Cache the loaded `spellID` per pet button and only (re)register the `ContinueWithCancelOnSpellLoad` callback when it actually changes, instead of on every `UpdatePet`. Avoids stacked callbacks and stale `tooltipSubtext`.

### `oUF_Plugins/oUF_AuraBars.lua`, `oUF_AuraWatch.lua`, `oUF_AuraHighlight.lua`
`AuraFiltered[filter][unit]` can be nil (no auras of that filter yet) → `next(nil)` errors. Bail out early. For AuraBars/AuraWatch also snapshot the filtered set into a local array before iterating, so callbacks that mutate `AuraFiltered` mid-loop can't break `next()`'s traversal.

## Notes
Supersedes the stale #1830 (which was ~157 commits behind `main`); companion to #1843 and #1844.

