### PR TITLE
feat: hide questmap borderframe

### DIFF
--- a/ElvUI/Game/Mainline/Skins/WorldMap.lua
+++ b/ElvUI/Game/Mainline/Skins/WorldMap.lua
@@ -226,6 +226,8 @@ function S:WorldMapFrame()
 	QuestMapFrame:SetScript('OnHide', S.WorldMap_QuestMapHide)
 
 	local DetailsFrame = QuestMapFrame.DetailsFrame
+	DetailsFrame.BorderFrame:SetAlpha(0)
+	
 	S:HandleButton(DetailsFrame.BackFrame.BackButton, true)
 	S:HandleButton(DetailsFrame.AbandonButton, true)
 	DetailsFrame.ShareButton:StripTextures() -- strip the Blizz Art around from it


### PR DESCRIPTION
Hides the borderframe around the questmap detailsframe.