### PR TITLE
feat: use default status dropdown position

### DIFF
--- a/ElvUI/Game/Mainline/Skins/Friends.lua
+++ b/ElvUI/Game/Mainline/Skins/Friends.lua
@@ -268,9 +268,6 @@ function S:FriendsFrame()
 
 	S:HandleDropDownBox(_G.FriendsFrameStatusDropdown, 70)
 
-	_G.FriendsFrameStatusDropdown:ClearAllPoints()
-	_G.FriendsFrameStatusDropdown:Point('TOPLEFT', FriendsFrame, 'TOPLEFT', 5, -24)
-
 	local FriendsFrameBattlenetFrame = _G.FriendsFrameBattlenetFrame
 	FriendsFrameBattlenetFrame:StripTextures()
 	FriendsFrameBattlenetFrame:SetTemplate('Transparent')


### PR DESCRIPTION
Looks a bit cleaner with the wider FriendsFrame.
<img width="420" height="205" alt="Screenshot 2026-06-07 123303" src="https://github.com/user-attachments/assets/48f256de-b5a4-418a-8721-0b1063eaf1a7" />