### PR TITLE
perf(oUF): compute per-aura filter flags once instead of per-filter

### DIFF
--- a/ElvUI_Libraries/Game/Shared/oUF/auraskip.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF/auraskip.lua
@@ -53,25 +53,25 @@ local function InstanceFiltered(unit, aura, helpful, harmful)
 	return isHelpful or isHarmful
 end
 
-local function UpdateFilter(which, filter, filtered, allow, unit, auraInstanceID, aura)
+-- These flags are per-aura and do NOT depend on the filter, so compute them
+-- once instead of recomputing identical values inside the 3x filter loop.
+local function ComputeAuraFlags(unit, aura)
+	aura.auraIsHarmful = not IsAuraFilteredOutByInstanceID(unit, aura.auraInstanceID, 'HARMFUL')
+	aura.auraIsHelpful = not IsAuraFilteredOutByInstanceID(unit, aura.auraInstanceID, 'HELPFUL')
+
+	aura.auraIsImportant = InstanceFiltered(unit, aura, 'HELPFUL|IMPORTANT', 'HARMFUL|IMPORTANT')
+	aura.auraIsCancelable = InstanceFiltered(unit, aura, 'HELPFUL|CANCELABLE', 'HARMFUL|CANCELABLE')
+	aura.auraIsCrowdControl = InstanceFiltered(unit, aura, 'HELPFUL|CROWD_CONTROL', 'HARMFUL|CROWD_CONTROL')
+	aura.auraIsBigDefensive = InstanceFiltered(unit, aura, 'HELPFUL|BIG_DEFENSIVE', 'HARMFUL|BIG_DEFENSIVE')
+	aura.auraIsExternalDefensive = InstanceFiltered(unit, aura, 'HELPFUL|EXTERNAL_DEFENSIVE', 'HARMFUL|EXTERNAL_DEFENSIVE')
+	aura.auraIsPlayer = InstanceFiltered(unit, aura, 'HELPFUL|PLAYER', 'HARMFUL|PLAYER')
+	aura.auraIsRaid = InstanceFiltered(unit, aura, 'HELPFUL|RAID', 'HARMFUL|RAID')
+	aura.auraIsRaidInCombat = InstanceFiltered(unit, aura, 'HELPFUL|RAID_IN_COMBAT', 'HARMFUL|RAID_IN_COMBAT') -- Auras flagged to show on raid frames in combat
+	aura.auraIsRaidPlayerDispellable = InstanceFiltered(unit, aura, 'HELPFUL|RAID_PLAYER_DISPELLABLE', 'HARMFUL|RAID_PLAYER_DISPELLABLE') -- Auras with a dispel type the player can dispel
+end
+
+local function UpdateFilter(filter, filtered, allowed, unit, auraInstanceID, aura)
 	local unitAuraFiltered = filtered[unit]
-
-	local allowed = which ~= 'remove' and allow and aura
-	if allowed then -- irrelevant filters: IncludeNameplateOnly, Maw
-		aura.auraIsHarmful = not IsAuraFilteredOutByInstanceID(unit, aura.auraInstanceID, 'HARMFUL')
-		aura.auraIsHelpful = not IsAuraFilteredOutByInstanceID(unit, aura.auraInstanceID, 'HELPFUL')
-
-		aura.auraIsImportant = InstanceFiltered(unit, aura, 'HELPFUL|IMPORTANT', 'HARMFUL|IMPORTANT')
-		aura.auraIsCancelable = InstanceFiltered(unit, aura, 'HELPFUL|CANCELABLE', 'HARMFUL|CANCELABLE')
-		aura.auraIsCrowdControl = InstanceFiltered(unit, aura, 'HELPFUL|CROWD_CONTROL', 'HARMFUL|CROWD_CONTROL')
-		aura.auraIsBigDefensive = InstanceFiltered(unit, aura, 'HELPFUL|BIG_DEFENSIVE', 'HARMFUL|BIG_DEFENSIVE')
-		aura.auraIsExternalDefensive = InstanceFiltered(unit, aura, 'HELPFUL|EXTERNAL_DEFENSIVE', 'HARMFUL|EXTERNAL_DEFENSIVE')
-		aura.auraIsPlayer = InstanceFiltered(unit, aura, 'HELPFUL|PLAYER', 'HARMFUL|PLAYER')
-		aura.auraIsRaid = InstanceFiltered(unit, aura, 'HELPFUL|RAID', 'HARMFUL|RAID')
-		aura.auraIsRaidInCombat = InstanceFiltered(unit, aura, 'HELPFUL|RAID_IN_COMBAT', 'HARMFUL|RAID_IN_COMBAT') -- Auras flagged to show on raid frames in combat
-		aura.auraIsRaidPlayerDispellable = InstanceFiltered(unit, aura, 'HELPFUL|RAID_PLAYER_DISPELLABLE', 'HARMFUL|RAID_PLAYER_DISPELLABLE') -- Auras with a dispel type the player can dispel
-	end
-
 	unitAuraFiltered[auraInstanceID] = not oUF:ShouldSkipAuraFilter(aura, filter) and allowed or nil
 end
 
@@ -97,8 +97,13 @@ local function UpdateAuraFilters(which, frame, event, unit, showFunc, auraInstan
 	unitAuraInfo[auraInstanceID] = (which ~= 'remove' and aura) or nil
 
 	local allow = (which == 'remove') or not aura or AllowAura(frame, aura)
+	local allowed = which ~= 'remove' and allow and aura
+	if allowed then -- irrelevant filters: IncludeNameplateOnly, Maw
+		ComputeAuraFlags(unit, aura)
+	end
+
 	for filter, filtered in next, auraFiltered do
-		UpdateFilter(which, filter, filtered, allow, unit, auraInstanceID, aura)
+		UpdateFilter(filter, filtered, allowed, unit, auraInstanceID, aura)
 	end
 
 	if showFunc then


### PR DESCRIPTION
### Summary

`UpdateAuraFilters` (in `ElvUI_Libraries/Game/Shared/oUF/auraskip.lua`) loops the three aura filters (`HELPFUL`/`HARMFUL`/`RAID`) and calls `UpdateFilter` for each. `UpdateFilter` recomputed the **per-aura** `aura.auraIs*` flags inside that loop:

```
auraIsHarmful, auraIsHelpful, auraIsImportant, auraIsCancelable,
auraIsCrowdControl, auraIsBigDefensive, auraIsExternalDefensive,
auraIsPlayer, auraIsRaid, auraIsRaidInCombat, auraIsRaidPlayerDispellable
```

That's ~20 `C_UnitAuras.IsAuraFilteredOutByInstanceID` calls, multiplied by the 3 filters = **~60 API calls per aura per `UNIT_AURA`**. But those flags don't depend on the filter — only the final `ShouldSkipAuraFilter(aura, filter)` line does.

This PR extracts the flag computation into `ComputeAuraFlags()`, called **once per aura** before the filter loop. `UpdateFilter` now only does the filter-specific `unitAuraFiltered[auraInstanceID]` assignment. Result: **3× fewer filter API calls** per aura.

### Why it matters

This is the dominant cost of aura updates on nameplates during heavy pulls (many elite NPCs, each with several auras, firing `UNIT_AURA` constantly). On 12.0 the reduced work also keeps the pass under the tighter watchdog budget — I was reliably hitting `oUF/elements/auras.lua:197: script ran too long` on big pulls, which this resolves in testing.

### Behaviour

Identical. The flags written to the aura table and the value stored in `unitAuraFiltered` are unchanged; only the redundant recomputation is removed. `UpdateFilter`'s signature drops the now-unneeded `which`/`allow` params in favour of the precomputed `allowed` (single caller).