### PR TITLE
feat: update objectivetracker minimize art

### DIFF
--- a/ElvUI/Game/Mainline/Skins/ObjectiveTracker.lua
+++ b/ElvUI/Game/Mainline/Skins/ObjectiveTracker.lua
@@ -114,11 +114,11 @@ local function SetCollapsed(header, collapsed)
 	local pushedTexture = MinimizeButton:GetPushedTexture()
 
 	if collapsed then
-		normalTexture:SetAtlas('UI-QuestTrackerButton-Secondary-Expand', true)
-		pushedTexture:SetAtlas('UI-QuestTrackerButton-Secondary-Expand-Pressed', true)
+		normalTexture:SetTexture(E.Media.Textures.PlusButton)
+		pushedTexture:SetTexture(E.Media.Textures.PlusButton)
 	else
-		normalTexture:SetAtlas('UI-QuestTrackerButton-Secondary-Collapse', true)
-		pushedTexture:SetAtlas('UI-QuestTrackerButton-Secondary-Collapse-Pressed', true)
+		normalTexture:SetTexture(E.Media.Textures.MinusButton)
+		pushedTexture:SetTexture(E.Media.Textures.MinusButton)
 	end
 end
 
@@ -132,8 +132,7 @@ function S:Blizzard_ObjectiveTracker()
 
 		local MinimizeButton = TrackerHeader.MinimizeButton
 		if MinimizeButton then
-			MinimizeButton:Size(16)
-			MinimizeButton:SetHighlightAtlas('UI-QuestTrackerButton-Yellow-Highlight', 'ADD')
+			MinimizeButton:Size(15)
 
 			SetCollapsed(TrackerHeader, TrackerFrame.isCollapsed)
 			hooksecurefunc(TrackerHeader, 'SetCollapsed', SetCollapsed)
@@ -146,6 +145,15 @@ function S:Blizzard_ObjectiveTracker()
 		hooksecurefunc(tracker, 'AddBlock', HandleQuestIcons)
 		hooksecurefunc(tracker, 'GetProgressBar', HandleProgressBar)
 		hooksecurefunc(tracker, 'GetTimerBar', HandleTimers)
+
+		local MinimizeButton = tracker.Header.MinimizeButton
+		if MinimizeButton then
+			MinimizeButton:Size(15)
+			MinimizeButton:SetHighlightAtlas('ui-questtrackerbutton-red-highlight', 'ADD')
+
+			SetCollapsed(tracker.Header, TrackerFrame.isCollapsed)
+			hooksecurefunc(tracker.Header, 'SetCollapsed', SetCollapsed)
+		end
 	end
 end
 


### PR DESCRIPTION
Restores the custom ElvUI plus/min textures for the ObjectiveTracker's minimize buttons.
<img width="272" height="261" alt="Screenshot 2026-06-13 125708" src="https://github.com/user-attachments/assets/4a6d9428-7123-4cff-925b-4a0544d394e6" />