### PR TITLE
fix: use correct scrollbar template

### DIFF
--- a/ElvUI/Game/Mainline/Skins/Guide.lua
+++ b/ElvUI/Game/Mainline/Skins/Guide.lua
@@ -32,7 +32,7 @@ function S:Blizzard_NewPlayerExperienceGuide()
 	frame.Title:SetTextColor(1, 1, 1)
 
 	local scrollFrame = frame.ScrollFrame
-	S:HandleScrollBar(scrollFrame.ScrollBar)
+	S:HandleTrimScrollBar(scrollFrame.ScrollBar)
 	S:HandleButton(scrollFrame.ConfirmationButton)
 
 	local scrollChild = scrollFrame.Child


### PR DESCRIPTION
The GuideFrame was using the wrong scrollbar template, this fixes that.
<img width="370" height="627" alt="1" src="https://github.com/user-attachments/assets/8039009a-fe8f-4b6a-a039-d8e864eee198" />
<img width="376" height="628" alt="2" src="https://github.com/user-attachments/assets/a9587cb7-949a-4822-a1cf-62f7dc5c45cf" />
