### PR TITLE
fix(12.0): guard secret values in aura update path (script ran too long)

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Auras.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Auras.lua
@@ -801,8 +801,14 @@ function UF:AuraFilter(element, unit, button, aura, name, icon, count, debuffTyp
 	if not name then return end -- checking for an aura that is not there, pass nil to break while loop
 	local db = element.db
 
-	-- this should be secret safe, rest are populated in oUF or AuraPopulate
-	button.isFriend = UnitIsFriend('player', unit) and not UnitCanAttack('player', unit)
+	-- rest are populated in oUF or AuraPopulate
+	-- In Midnight, UnitIsFriend/UnitCanAttack can return SECRET booleans (e.g. in instances/arenas).
+	-- Leaving them raw makes button.isFriend secret, so the later `not button.isFriend` in
+	-- PostUpdateAura/CheckFilter taints the per-aura update loop -> "script ran too long".
+	-- Coerce to plain booleans; a secret relationship defaults to "not friend" (cosmetic only).
+	local isFriend = UnitIsFriend('player', unit)
+	local canAttack = UnitCanAttack('player', unit)
+	button.isFriend = (E:NotSecretValue(isFriend) and isFriend) and not (E:NotSecretValue(canAttack) and canAttack) or false
 	button.canDesaturate = (db and db.desaturate) or false
 
 	if not db or not aura then

--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
@@ -187,6 +187,14 @@ local function UpdateIcon(element, unit, aura, index, offset, filter, isDebuff, 
 	local name, icon, count, debuffType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID, canApplyAura, isBossDebuff, castByPlayer, nameplateShowAll, modRate, effect1, effect2, effect3 = oUF:UnpackAuraData(aura)
 	if not name then return end
 
+	-- In Midnight, secret auras return a secret count (applications) and a secret castByPlayer
+	-- boolean. This AuraWatch path uses them raw in CustomFilter/HandleElements (`count < 1`,
+	-- `count > 1`, `setting.anyUnit and button.castByPlayer`), which taints the FilterIcons loop
+	-- -> "script ran too long". Coerce to safe, non-secret values (count 0 = no stack text,
+	-- castByPlayer nil = treated as not-by-player for anyUnit watches).
+	if oUF:IsSecretValue(count) then count = 0 end
+	if oUF:IsSecretValue(castByPlayer) then castByPlayer = nil end
+
 	local button, position = FetIcon(element, visible, offset)
 
 	button.aura = aura


### PR DESCRIPTION
## Summary

Two unguarded secret-value reads in Midnight (12.x) taint the **per-aura update loop**, which collapses the drastically reduced tainted-execution budget and trips `script ran too long`. As with other 12.0 taint reports, the line in the stack (`Auras.lua` `PostUpdateButton`, `oUF_AuraWatch.lua:246`) is just where the watchdog fires — the real cause is taint introduced earlier in the same loop.

### 1. UnitFrames `Auras.lua` — `button.isFriend`

```lua
-- this should be secret safe, rest are populated in oUF or AuraPopulate
button.isFriend = UnitIsFriend('player', unit) and not UnitCanAttack('player', unit)
```

The comment assumes this is secret-safe, but in Midnight `UnitIsFriend` / `UnitCanAttack` return **secret booleans** in instances/arenas (same as `UnitInRange`). `button.isFriend` then becomes secret, and `not button.isFriend` in `PostUpdateAura` (`SetDesaturated`) and `CheckFilter` taints the loop. Fixed by coercing both to plain booleans via `E:NotSecretValue` (a secret relationship defaults to "not friend" — cosmetic only).

### 2. `oUF_AuraWatch.lua` — secret `count` / `castByPlayer`

`UpdateIcon` uses `count` (applications) and `castByPlayer` raw in `CustomFilter`/`HandleElements` (`count < 1`, `count > 1`, `setting.anyUnit and button.castByPlayer`). Both are secret for secret auras — note the main oUF aura element already guards `applications` via `oUF:IsSecretValue`. Fixed by coercing secret `count -> 0` and secret `castByPlayer -> nil` right after `UnpackAuraData`.

## Notes

Both changes are strict no-ops when the values aren't secret (zero regression outside Midnight instanced content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)