### PR TITLE
fix(12.0): defer LFG applicant skinning to avoid tainting Blizzard's sort

### DIFF
--- a/ElvUI/Game/Mainline/Skins/LFG.lua
+++ b/ElvUI/Game/Mainline/Skins/LFG.lua
@@ -590,7 +590,12 @@ function S:LookingForGroupFrames()
 		ApplicationViewer.Inset:StripTextures()
 		ApplicationViewer.Inset:SetTemplate('Transparent')
 
-		S:HandleButton(ApplicationViewer.NameColumnHeader)
+		-- Midnight: skinning ApplicationViewer buttons here taints the frame in the same
+	-- execution pass as Blizzard's LFGListApplicationViewer_UpdateInfo, causing
+	-- secret-value comparison errors ("attempt to compare field 'comment'").
+	-- Defer skinning so it runs in a clean, untainted thread.
+	C_Timer.After(0, function()
+	S:HandleButton(ApplicationViewer.NameColumnHeader)
 		S:HandleButton(ApplicationViewer.RoleColumnHeader)
 		S:HandleButton(ApplicationViewer.ItemLevelColumnHeader)
 		S:HandleButton(ApplicationViewer.RatingColumnHeader)
@@ -623,7 +628,8 @@ function S:LookingForGroupFrames()
 		ApplicationViewer.BrowseGroupsButton:Size(120, 22)
 
 		S:HandleTrimScrollBar(ApplicationViewer.ScrollBar)
-	end
+	end)
+end
 
 	-- Same as UpdateApplicant: this runs in Blizzard's secure pass and mutates frames + reads
 	-- UnitIsGroupLeader (a secret-prone boolean in Midnight) on every call, tainting the thread

--- a/ElvUI/Game/Mainline/Skins/LFG.lua
+++ b/ElvUI/Game/Mainline/Skins/LFG.lua
@@ -551,16 +551,26 @@ function S:LookingForGroupFrames()
 		end
 	end
 
+	-- Midnight: this hook runs inside Blizzard's secure applicant-update pass. Skinning the
+	-- buttons inline (StripTextures/SetTemplate) taints the execution thread, and that taint
+	-- propagates to the caller (LFGListApplicationViewer_UpdateResultList), so Blizzard's own
+	-- LFGListUtil_SortApplicants then errors comparing the secret 'isNew' field
+	-- ("attempt to compare ... a secret boolean value, while execution tainted by 'ElvUI'").
+	-- Defer the frame work one frame so it runs in a clean, untainted execution.
 	hooksecurefunc('LFGListApplicationViewer_UpdateApplicant', function(button)
-		if not button.DeclineButton.template then
-			S:HandleButton(button.DeclineButton, nil, true)
-		end
-		if not button.InviteButton.template then
-			S:HandleButton(button.InviteButton)
-		end
-		if not button.InviteButtonSmall.template then
-			S:HandleButton(button.InviteButtonSmall)
-		end
+		if button.DeclineButton.template and button.InviteButton.template and button.InviteButtonSmall.template then return end
+
+		C_Timer.After(0, function()
+			if not button.DeclineButton.template then
+				S:HandleButton(button.DeclineButton, nil, true)
+			end
+			if not button.InviteButton.template then
+				S:HandleButton(button.InviteButton)
+			end
+			if not button.InviteButtonSmall.template then
+				S:HandleButton(button.InviteButtonSmall)
+			end
+		end)
 	end)
 
 	hooksecurefunc('LFGListSearchEntry_Update', function(button)
@@ -615,14 +625,19 @@ function S:LookingForGroupFrames()
 		S:HandleTrimScrollBar(ApplicationViewer.ScrollBar)
 	end
 
+	-- Same as UpdateApplicant: this runs in Blizzard's secure pass and mutates frames + reads
+	-- UnitIsGroupLeader (a secret-prone boolean in Midnight) on every call, tainting the thread
+	-- that feeds LFGListUtil_SortApplicants. Defer it out of the secure execution.
 	hooksecurefunc('LFGListApplicationViewer_UpdateInfo', function(frame)
-		frame.RemoveEntryButton:ClearAllPoints()
+		C_Timer.After(0, function()
+			frame.RemoveEntryButton:ClearAllPoints()
 
-		if UnitIsGroupLeader('player', LE_PARTY_CATEGORY_HOME) then
-			frame.RemoveEntryButton:Point('RIGHT', frame.EditButton, 'LEFT', -2, 0)
-		else
-			frame.RemoveEntryButton:Point('BOTTOMLEFT', -1, 3)
-		end
+			if UnitIsGroupLeader('player', LE_PARTY_CATEGORY_HOME) then
+				frame.RemoveEntryButton:Point('RIGHT', frame.EditButton, 'LEFT', -2, 0)
+			else
+				frame.RemoveEntryButton:Point('BOTTOMLEFT', -1, 3)
+			end
+		end)
 	end)
 
 	hooksecurefunc('LFGListCategorySelection_AddButton', function(btn, btnIndex, categoryID, filters)


### PR DESCRIPTION
## Summary

In Midnight (12.x), opening the Premade Groups **applicant list** as group leader produces a recurring Blizzard error:

```
Blizzard_GroupFinder/Mainline/LFGList.lua:4002: attempt to compare field 'isNew'
(a secret boolean value, while execution tainted by 'ElvUI')
  ... in function 'sort'
  LFGListUtil_SortApplicants
  LFGListApplicationViewer_UpdateResultList
```

`LFGListUtil_SortApplicants` sorts applicants by the secret `isNew` field, which is only allowed during **untainted** execution.

The skin post-hooks on `LFGListApplicationViewer_UpdateApplicant` and `_UpdateInfo` do frame work (`StripTextures`/`SetTemplate`/`Point`) and read `UnitIsGroupLeader` **inside Blizzard's secure applicant-update pass**. That taint propagates to the caller (`UpdateResultList`), so the subsequent `sort` errors on the secret comparison.

## Fix

Defer the frame work one frame via `C_Timer.After(0)` so it runs in a clean, untainted execution (same approach used elsewhere for menu/secure-callback skinning). `UpdateApplicant` gets an early-return once all three buttons already carry `.template`, so it only schedules on first appearance.

The skin result is visually identical — buttons are skinned ~1 frame later.

## Note

This addresses the taint vector via the only ElvUI touch points in the applicant-update path. I don't have a way to read the (client-shipped) `Blizzard_GroupFinder` source to confirm the exact propagation, so this is a targeted, low-risk mitigation (no-op when the deferral isn't needed) rather than a fully traced fix — feedback welcome if there's a cleaner anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)