### PR TITLE
fix: editmode settings dropdowns not skinned

### DIFF
--- a/ElvUI/Game/Mainline/Skins/EditorManager.lua
+++ b/ElvUI/Game/Mainline/Skins/EditorManager.lua
@@ -35,15 +35,15 @@ local function HandleDialogs()
 	end
 
 	for _, frame in next, { dialog.Settings:GetChildren() } do
-		local checkbox = frame.Button
-		if checkbox and not checkbox.backdrop then
-			HandleCheckBox(checkbox)
-		end
-
 		local dropdown = frame.Dropdown
 		if dropdown and not dropdown.IsSkinned then
 			S:HandleDropDownBox(dropdown, 250)
 			dropdown.IsSkinned = true
+		end
+
+		local checkbox = frame.Button
+		if checkbox and not checkbox.backdrop then
+			HandleCheckBox(checkbox)
 		end
 	end
 end

--- a/ElvUI/Game/Mainline/Skins/EditorManager.lua
+++ b/ElvUI/Game/Mainline/Skins/EditorManager.lua
@@ -35,15 +35,15 @@ local function HandleDialogs()
 	end
 
 	for _, frame in next, { dialog.Settings:GetChildren() } do
-		local dd = frame.Dropdown
-		if dd and (dd.DropDownMenu and not dd.IsSkinned) then
-			S:HandleDropDownBox(dd.DropDownMenu, 250)
-			dd.IsSkinned = true
-		end
-
 		local checkbox = frame.Button
 		if checkbox and not checkbox.backdrop then
 			HandleCheckBox(checkbox)
+		end
+
+		local dropdown = frame.Dropdown
+		if dropdown and not dropdown.IsSkinned then
+			S:HandleDropDownBox(dropdown, 250)
+			dropdown.IsSkinned = true
 		end
 	end
 end


### PR DESCRIPTION
These dropdowns werent skinned properly.
<img width="419" height="139" alt="1" src="https://github.com/user-attachments/assets/5ade29e2-0eca-410c-8378-3859fe5eba19" />
<img width="408" height="142" alt="2" src="https://github.com/user-attachments/assets/55a51f8d-01ef-4834-ba31-7f99aee28d45" />
