### PR TITLE
fix: disable overlay casting bar

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -1857,6 +1857,7 @@ do
 				if E.hasEditMode then
 					if disable.castbar then
 						HideFrame(_G.PlayerCastingBarFrame)
+						HideFrame(_G.OverlayPlayerCastingBarFrame)
 						HideFrame(_G.PetCastingBarFrame)
 					end
 				elseif disable.castbar then


### PR DESCRIPTION
This frame causes lua errors (most noticeably after changing talents) and since its usage is very limited, its best to disable it.