### PR TITLE
fix(12.0): guard secret aura curve color in PostUpdateAura (script ran too long)

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Auras.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/Elements/Auras.lua
@@ -526,11 +526,14 @@ function UF:PostUpdateAura(unit, button)
 	local db, r, g, b = (self.isNameplate and NP.db.colors) or UF.db.colors
 	local steal = DebuffColors.Stealable
 
+	-- In Midnight, GetAuraDispelTypeColor (via GetAuraCurve) returns a color whose
+	-- r/g/b are SECRET numbers (see AuraHighlight's `secretColor`). Extracting them with
+	-- color:GetRGB() and then doing `if not r` below would branch on a secret value and
+	-- taint the per-aura update loop -> "script ran too long". Keep it as an object and
+	-- feed its components straight into the setter (widget setters accept secret values).
+	local curveColor
 	if E.Retail then
-		local color = not self.forceShow and UF:GetAuraCurve(unit, button, db.auraByType)
-		if color then
-			r, g, b = color:GetRGB()
-		end
+		curveColor = (not self.forceShow and UF:GetAuraCurve(unit, button, db.auraByType)) or nil
 	elseif button.isDebuff then
 		local bad = DebuffColors.BadDispel
 		if bad and db.auraByDispels and (BadDispels[button.spellID] and DispelTypes[button.debuffType]) then
@@ -543,11 +546,15 @@ function UF:PostUpdateAura(unit, button)
 		r, g, b = steal.r, steal.g, steal.b
 	end
 
-	if not r then
-		r, g, b = unpack((self.isNameplate and E.media.bordercolor) or E.media.unitframeBorderColor)
-	end
+	if curveColor then
+		button:SetBackdropBorderColor(curveColor:GetRGB())
+	else
+		if not r then
+			r, g, b = unpack((self.isNameplate and E.media.bordercolor) or E.media.unitframeBorderColor)
+		end
 
-	button:SetBackdropBorderColor(r, g, b)
+		button:SetBackdropBorderColor(r, g, b)
+	end
 	button.Icon:SetDesaturated(button.canDesaturate and button.isDebuff and not button.isFriend and not button.isPlayer)
 
 	if button.Text then


### PR DESCRIPTION
### Problem

In-game error in Midnight (12.x):

```
ElvUI_Libraries/.../oUF/elements/auras.lua:360: script ran too long
  auras.lua:360 in function <auras.lua:345>   (filterIcons)
  auras.lua:406 in function 'func'            (UpdateAuras)
  oUF/events.lua:85
```

`auras.lua:360` is just `if result == VISIBLE then` — it's where the watchdog tripped, not the bug. As with the other 12.0 taint reports, **tainted execution gets a drastically reduced budget**, so once the per-aura loop is tainted a later iteration trips "script ran too long".

### Root cause

`C_UnitAuras.GetAuraDispelTypeColor` returns a color whose `r`/`g`/`b` are **secret numbers**. ElvUI already treats it as secret everywhere else:

- `UnitFrames/Elements/AuraHighlight.lua` names the result `secretColor` and feeds `color.r/.g/.b` straight into the setter (never branches on them).
- The standalone `Auras/Auras.lua` does `color = (curve and GetAuraDispelTypeColor(...)) or fallback` and passes `color.r/.g/.b` directly into `SetBackdropBorderColor`.

But `UF:PostUpdateAura` (`UnitFrames/Elements/Auras.lua`) extracted the components:

```lua
if color then
    r, g, b = color:GetRGB()   -- r,g,b become SECRET numbers
end
...
if not r then                  -- <-- branches on a secret number -> TAINT
    r, g, b = unpack(fallback)
end
```

`if not r` branches on a secret number, tainting the per-aura update loop (`PostUpdateButton` runs for every visible aura), which collapses the script budget and trips the watchdog above.

### Fix

Mirror the AuraHighlight / standalone-Auras pattern: keep the curve result as an object (the object reference itself is not secret, only its fields are) and pass its components directly into `SetBackdropBorderColor`, never branching on the extracted numbers.

Strict no-op when the color is not secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)