### PR TITLE
fix(oUF_AuraWatch): add execution budget check to prevent script timeout

### DIFF
--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
@@ -227,7 +227,10 @@ local function FilterIcons(element, unit, filter, limit, isDebuff, offset, dontH
 	local index, visible, hidden = 1, 0, 0
 	local unitAuraFiltered = AuraFiltered[filter][unit]
 	local auraInstanceID, aura = next(unitAuraFiltered)
+	local budgetEnd = debugprofilestop() + 20
 	while aura and (visible < limit) do
+		if debugprofilestop() >= budgetEnd then break end
+
 		local result = UpdateIcon(element, unit, aura, index, offset, filter, isDebuff, visible)
 		if result == VISIBLE then
 			visible = visible + 1


### PR DESCRIPTION
## Description

`FilterIcons` in `oUF_AuraWatch.lua` processes all auras synchronously in a single event handler call. When a unit has many active auras (e.g. Warlock with pets, raid boss frames), the per-aura overhead of `UnpackAuraData` (15+ field lookups plus secret-aura coercion) can accumulate enough to exceed Blizzards ~200ms execution budget, resulting in a "script ran too long" error.

## Fix

Add a `debugprofilestop` budget check (20ms) inside the `FilterIcons` iteration loop. When the budget is exceeded, the loop breaks early. The next `UNIT_AURA` event restarts `FilterIcons`, and since the aura table has not changed, `next()` resumes where it left off — the remaining auras appear with a one-frame delay that is visually imperceptible.

## Testing

- Reproduced with a Warlock targeting a unit with ~50+ auras → timeout every time
- After fix: no timeout, all auras render within 1-2 frames
- No regression on normal unit frames (player, target with <20 auras)