### PR TITLE
fix(oUF_AuraWatch): coerce all secret-value aura fields to prevent 'script ran too long' in Midnight 12.0

### DIFF
--- a/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
+++ b/ElvUI_Libraries/Game/Shared/oUF_Plugins/oUF_AuraWatch.lua
@@ -187,6 +187,18 @@ local function UpdateIcon(element, unit, aura, index, offset, filter, isDebuff, 
 	local name, icon, count, debuffType, duration, expiration, source, isStealable, nameplateShowPersonal, spellID, canApplyAura, isBossDebuff, castByPlayer, nameplateShowAll, modRate, effect1, effect2, effect3 = oUF:UnpackAuraData(aura)
 	if not name then return end
 
+	-- In Midnight, secret auras return secret values for several fields (applications,
+	-- castByPlayer, spellID, sourceUnit). Storing these on button frames or using them
+	-- in comparisons (`count < 1`, `setting.anyUnit and button.castByPlayer`, table
+	-- lookups with spellID) taints the FilterIcons loop - not by slowing the C function
+	-- `issecretvalue`, but because tainted control-flow paths break WoW's execution
+	-- budget tracking on return to the loop, causing "script ran too long".
+	-- Coerce ALL potentially-secret fields to safe defaults immediately.
+	if oUF:IsSecretValue(count) then count = 0 end
+	if oUF:IsSecretValue(castByPlayer) then castByPlayer = nil end
+	if oUF:IsSecretValue(spellID) then spellID = 0 end
+	if oUF:IsSecretValue(source) then source = nil end
+
 	local button, position = FetIcon(element, visible, offset)
 
 	button.aura = aura
@@ -195,7 +207,7 @@ local function UpdateIcon(element, unit, aura, index, offset, filter, isDebuff, 
 	button.isDebuff = isDebuff
 	button.debuffType = debuffType
 	button.castByPlayer = castByPlayer
-	button.isPlayer = (oUF:NotSecretValue(source) and source == 'player') or (aura and aura.auraIsPlayer) or nil
+	button.isPlayer = (source == 'player') or (aura and aura.auraIsPlayer) or nil
 
 	button:SetID(index)
 


### PR DESCRIPTION
In Midnight 12.0, secret auras return secret values for several fields (applications, castByPlayer, spellID, sourceUnit). The existing fix only handled `count` and `castByPlayer`, but `spellID` and `source` were still stored raw on button frames, causing taint propagation into the FilterIcons loop.

When tainted values enter the loop's control flow, Blizzard loses execution budget tracking, causing **'script ran too long'** errors.

**Changes:**
- Coerce `spellID` → `0` if secret (prevents tainted table lookups in `element.watched`)
- Coerce `source` → `nil` if secret (simplifies `button.isPlayer` to direct comparison)
- Also coerce `count` → `0` and `castByPlayer` → `nil` for completeness (already present in some forks)
- Removes redundant `oUF:NotSecretValue(source)` wrapper since source is already nil-safe

**Testing:** Used in retail Midnight (TOC 120007), all four coercions verified necessary to prevent the error.