### PR TITLE
Fix invalid percent slider input

### DIFF
--- a/ElvUI_Libraries/Game/Shared/Ace3-ElvUI/AceGUIWidget-Slider-ElvUI.lua
+++ b/ElvUI_Libraries/Game/Shared/Ace3-ElvUI/AceGUIWidget-Slider-ElvUI.lua
@@ -98,9 +98,11 @@ local function EditBox_OnEnterPressed(frame)
 	local value = frame:GetText()
 	if self.ispercent then
 		value = value:gsub('%%', '')
-		value = tonumber(value) / 100
-	else
-		value = tonumber(value)
+	end
+
+	value = tonumber(value)
+	if value and self.ispercent then
+		value = value / 100
 	end
 
 	if value then


### PR DESCRIPTION
## What changed

- Parse slider edit box input before applying percent conversion.
- Only divide percent values when numeric conversion succeeds.

## Why

Submitting empty or otherwise non-numeric text in a percent slider currently makes `tonumber` return `nil`, after which the widget attempts `nil / 100`. This raises `attempt to perform arithmetic on a nil value` from `AceGUIWidget-Slider-ElvUI.lua`.

Invalid input is now ignored consistently with non-percent sliders, while valid percent input keeps the existing behavior.

## Validation

- `git diff --check`
- Reviewed both valid and invalid percent-input paths
