### PR TITLE
Toolkit: avoid tainting the Blizzard overlay cast bar

### DIFF
--- a/ElvUI/Game/Shared/General/Toolkit.lua
+++ b/ElvUI/Game/Shared/General/Toolkit.lua
@@ -7,6 +7,7 @@ local strsub, type = strsub, type
 local next, pcall, unpack = next, pcall, unpack
 local hooksecurefunc = hooksecurefunc
 local getmetatable = getmetatable
+local setmetatable = setmetatable
 local tonumber = tonumber
 
 local FontStringScaleAnimationMode = Enum.FontStringScaleAnimationMode
@@ -103,14 +104,18 @@ function E:ReplaceSetupTextureCoordinates(frame) -- temp until blizzard fixes th
 	end
 end
 
+local pixelSnapDisabled = setmetatable({}, { __mode = 'k' })
+
 local function WatchPixelSnap(frame, snap)
-	if E:NotSecretTable(frame) and (frame and not frame:IsForbidden()) and frame.PixelSnapDisabled and snap then
-		frame.PixelSnapDisabled = nil
+	if E:NotSecretTable(frame) and (frame and not frame:IsForbidden()) and pixelSnapDisabled[frame] and snap then
+		pixelSnapDisabled[frame] = nil
 	end
 end
 
 local function DisablePixelSnap(frame)
-	if E:NotSecretTable(frame) and (frame and not frame:IsForbidden()) and not frame.PixelSnapDisabled then
+	if frame == _G.OverlayPlayerCastingBarFrame then return end
+
+	if E:NotSecretTable(frame) and (frame and not frame:IsForbidden()) and not pixelSnapDisabled[frame] then
 		if frame.SetSnapToPixelGrid then
 			frame:SetSnapToPixelGrid(false)
 			frame:SetTexelSnappingBias(0)
@@ -122,7 +127,7 @@ local function DisablePixelSnap(frame)
 			end
 		end
 
-		frame.PixelSnapDisabled = true
+		pixelSnapDisabled[frame] = true
 	end
 end
 


### PR DESCRIPTION
## Problem

The pixel-snap hooks run on Blizzard widgets as well as ElvUI-owned objects. When `OverlayPlayerCastingBarFrame` receives a status bar texture, `DisablePixelSnap` modifies that Blizzard frame and stores its bookkeeping on the widget.

The overlay cast bar now handles secret cast state. Once its execution is tainted, Blizzard can no longer index or iterate `CastingBarTypeInfo` while processing a secret `barType`:

```
CastingBarFrame.lua:212: attempted to index a table that cannot be accessed while tainted
CastingBarFrame.lua:722: attempted to iterate a table that cannot be accessed while tainted
```

## Fix

Keep the pixel-snap bookkeeping in a private weak-key table instead of writing it to widget objects. Also leave `OverlayPlayerCastingBarFrame` untouched by `DisablePixelSnap`, while preserving the existing behavior for other widgets.

Blizzard code involved: [CastingBarFrame.lua](https://github.com/Gethe/wow-ui-source/blob/live/Interface/AddOns/Blizzard_UIPanels_Game/Mainline/CastingBarFrame.lua#L207-L213)

## Tested

- Retail 12.0.7 / ElvUI 15.18.
- Repeated completed and cancelled casts across several combats after `/reload`.
- `taintLog 2` captured 6,040 additional lines from 16:08 to 16:42 with no `CastingBarFrame`, `OverlayPlayerCastingBarFrame`, `CastingBarTypeInfo`, `PixelSnapDisabled`, or pixel-snap hook entries.
- No casting-bar errors during the test window.
- `git diff --check` passes.