### PR TITLE
Minimap: parent the cluster holder to UIParent to stop edit mode blocking

### DIFF
--- a/ElvUI/Game/Shared/Modules/Maps/Minimap.lua
+++ b/ElvUI/Game/Shared/Modules/Maps/Minimap.lua
@@ -801,9 +801,9 @@ function M:Initialize()
 	M.MapHolder = mapHolder
 	M:SetScale(mapHolder, 1)
 
-	local clusterHolder = CreateFrame('Frame', 'ElvUI_MinimapClusterHolder', MinimapCluster)
+	local clusterHolder = CreateFrame('Frame', 'ElvUI_MinimapClusterHolder', E.UIParent)
 	clusterHolder.savedWidth, clusterHolder.savedHeight = MinimapCluster:GetSize()
-	clusterHolder:Point('TOPRIGHT', E.UIParent, -3, -3)
+	clusterHolder:Point('TOPRIGHT', -3, -3)
 	clusterHolder:SetSize(clusterHolder.savedWidth, clusterHolder.savedHeight)
 	clusterHolder:SetFrameLevel(10) -- over minimap mover
 	E:CreateMover(clusterHolder, 'MinimapClusterMover', L["Minimap Cluster"], nil, nil, nil, nil, nil, 'maps,minimap')


### PR DESCRIPTION
## The problem

With the minimap module enabled on retail, switching specs (or anything else that makes the game re-apply an edit mode layout) throws:

```
[ADDON_ACTION_BLOCKED] AddOn 'ElvUI' tried to call the protected function 'MinimapCluster:ClearAllPointsBase()'.
[C]: in function 'UpdateLayoutInfo'
[Interface/AddOns/Blizzard_EditMode/Shared/EditModeManager.lua]:185: in function <.../AddOns/Blizzard_EditMode/Shared/EditModeManager.lua:176>
```

and the layout apply aborts mid-way (`layoutApplyInProgress` stays true), leaving edit mode broken until reload.

## Why it happens

`ElvUI_MinimapClusterHolder` is created as a **child of MinimapCluster**, and `M:ClusterPoint` then anchors `MinimapCluster` TOPRIGHT to that same holder. So the cluster - a secure edit mode system frame - has its rect defined by an insecure addon frame that lives inside its own anchor family.

When `EditModeManagerFrameMixin:UpdateLayoutInfo` runs (`InitSystemAnchors`/`ApplySystemAnchor`), the secure code calls `ClearAllPoints()` on every registered system frame. For the cluster that resolves through our insecure holder, the call gets attributed to ElvUI and blocked.

This is exactly the setup 67b18d4 ("minimap: fix the actual error causing editmode to break") removed for `ElvUI_MinimapHolder` - the map holder used to be a child of `Minimap` and got the same treatment. The cluster holder kept the old pattern, so the cluster path still breaks.

## The fix

Parent the cluster holder to `E.UIParent` like the map holder, and drop the now-redundant explicit anchor frame in `Point`. Two lines, mirrors 67b18d4.

The mover keeps working (it never relied on the parent; `ClusterSize`/`UpdateSettings` size the holder explicitly), and `ClusterPoint` still anchors the cluster to the holder - but the holder is no longer part of the cluster's own frame tree, so edit mode can move the cluster securely again.

Repro: with the minimap module enabled on retail, swap specs (or apply another edit mode layout) - the current code hits the block every time. With the holder parented to UIParent the cluster rect no longer resolves through an insecure frame in its own tree, which is the condition the block keys on.
