### PR TITLE
ActionBars: no-op layout and grid methods on the disabled Blizzard bars

### DIFF
--- a/ElvUI/Game/Shared/Modules/ActionBars/ActionBars.lua
+++ b/ElvUI/Game/Shared/Modules/ActionBars/ActionBars.lua
@@ -1222,6 +1222,25 @@ do
 		OverrideActionBarButton = E.Wrath or E.Mists or nil
 	}
 
+	-- These bars stay registered as Edit Mode systems, so Edit Mode still runs UpdateSystem on
+	-- them (eg opening PlayerSpellsFrame via TOGGLETALENTS re-applies the layout). Since we
+	-- reparent them into our hidden frame they carry our taint, and every protected setter that
+	-- UpdateSystem drives through ApplySystemAnchor and AnchorSelectionFrame gets blocked one by
+	-- one. They are fully disabled and we never use their layout, so no-op that whole set.
+	local noops = { 'ClearAllPoints', 'SetPoint', 'SetSize', 'SetScale', 'SetAlpha', 'SetShown', 'SetFrameStrata', 'SetFrameLevel', 'SetClampRectInsets' }
+
+	-- Opening the spell book (or picking up an action) makes Blizzard show every action
+	-- button's empty grid, which calls SetShown on the buttons of the bars above. Those
+	-- buttons are children of frames we reparented, so they carry our taint and the call is
+	-- blocked. We use our own buttons, so no-op the visibility setters on the Blizzard ones.
+	local buttonNoops = { 'SetShown', 'Show', 'Hide' }
+	local actionButtons = {
+		'ActionButton',
+		'MultiBarBottomLeftButton', 'MultiBarBottomRightButton',
+		'MultiBarLeftButton', 'MultiBarRightButton',
+		'MultiBar5Button', 'MultiBar6Button', 'MultiBar7Button'
+	}
+
 	local settingsHider = CreateFrame('Frame')
 	settingsHider:SetScript('OnEvent', function(frame, event)
 		HideUIPanel(_G.SettingsPanel)
@@ -1278,6 +1297,27 @@ do
 			if frame then
 				frame:SetParent(E.HiddenFrame)
 				frame:UnregisterAllEvents()
+
+				for _, func in next, noops do
+					if frame[func] ~= E.noop then
+						frame[func] = E.noop
+					end
+				end
+			end
+		end
+
+		for _, name in next, actionButtons do
+			local index = 1
+			local button = _G[name..index]
+			while button do
+				for _, func in next, buttonNoops do
+					if button[func] ~= E.noop then
+						button[func] = E.noop
+					end
+				end
+
+				index = index + 1
+				button = _G[name..index]
 			end
 		end
 


### PR DESCRIPTION
## The problem

Frames we disable still get protected calls from Blizzard and, because we tainted them, those calls are blocked. Two paths:

**Edit Mode layout** - opening an Edit Mode managed panel re-applies the layout and walks every registered system, including our disabled bars:

```
[ADDON_ACTION_BLOCKED] ElvUI tried to call the protected function 'MultiBarBottomLeft:SetFrameStrata()'.
[ADDON_ACTION_BLOCKED] ElvUI tried to call the protected function 'MultiBarBottomLeft:SetClampRectInsets()'.
[C]: in function 'UpdateLayoutInfo'
```

**Action grid** - opening the spell book makes Blizzard show every action button's empty grid, calling `SetShown` on the child buttons of those bars:

```
[ADDON_ACTION_BLOCKED] ElvUI tried to call the protected function 'MultiBarBottomLeftButton1:SetShown()'.
[Interface/AddOns/Blizzard_FrameXMLUtil/Mainline/PlayerSpellsUtil.lua]:99: in function 'ToggleSpellBookFrame'
[TOGGLESPELLBOOK]:1
```

## Why

`AB:DisableBlizzard` reparents every frame in the `untaint` table into `E.HiddenFrame` and unregisters its events, which taints them (and their child buttons). It does not - and cannot really - take them out of Edit Mode's `registeredSystemFrames`, so `UpdateSystem` keeps running on them and drives protected setters through `ApplySystemAnchor` and `AnchorSelectionFrame`. The buttons get hit separately by the grid-show `SetShown`.

We already had the mitigation for the bar half: `AB:SetNoopsi` no-oped `ClearAllPoints/SetPoint/SetScale/SetShown` on exactly these frames. But it was called under `if not E.hasEditMode`, so it never ran where Edit Mode is the thing managing them, and 8524579 (era: edit mode) removed the helper along with the `hasEditMode` branches.

## The change

Re-apply the no-ops in the `DisableBlizzard` loop and cover the full setter set `UpdateSystem` uses (`ClearAllPoints, SetPoint, SetSize, SetScale, SetAlpha, SetShown, SetFrameStrata, SetFrameLevel, SetClampRectInsets`), plus no-op the visibility setters (`SetShown, Show, Hide`) on the action buttons of those bars.

These bars and buttons are fully disabled - hidden, reparented, events off - and we use our own bars/buttons, so nothing in ElvUI relies on their layout or visibility (grepped: the Blizzard action button globals are not referenced anywhere in the action bar module). Dropping those calls is safe.

## Testing

Retail: spec swaps, opening talents and the spell book via keybind, entering/leaving Edit Mode and applying a different layout, plus a long combat session, no longer produce the blocks, and the ElvUI bars/buttons still work normally.
