### PR TITLE
UnitFrames: stop the overlay cast bar erroring off our tainted player bar

### DIFF
--- a/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
+++ b/ElvUI/Game/Shared/Modules/UnitFrames/UnitFrames.lua
@@ -1854,6 +1854,17 @@ do
 				if disable.castbar then
 					HideFrame(_G.PlayerCastingBarFrame)
 					HideFrame(_G.PetCastingBarFrame)
+
+					-- The overlay bar (talent commit, crafting, override bar) reaches into
+					-- PlayerCastingBarFrame from StartReplacingPlayerBarAt, which we just tainted
+					-- by reparenting it, so the overlay bar ends up tainted as well and then errors
+					-- out of its own UNIT_SPELLCAST handler. We replace the player cast bar anyway,
+					-- so turn its events off. Nothing re-registers them and the talent frame falls
+					-- back to its commit spinner.
+					local overlay = _G.OverlayPlayerCastingBarFrame
+					if overlay then
+						overlay:UnregisterAllEvents()
+					end
 				end
 			elseif disable.player and unit == 'pet' then
 				HideFrame(_G.PetFrame)


### PR DESCRIPTION
## The problem

After committing a talent change, every following cast throws:

```
attempted to iterate a table that cannot be accessed while tainted (execution tainted by 'ElvUI')
[C]: in function '(for generator)'
[Interface/AddOns/Blizzard_UIPanels_Game/Mainline/CastingBarFrame.lua]:722: in function 'StopFinishAnims'
[Interface/AddOns/Blizzard_UIPanels_Game/Mainline/CastingBarFrame.lua]:732: in function 'StopAnims'
[Interface/AddOns/Blizzard_UIPanels_Game/Mainline/CastingBarFrame.lua]:364: in function <.../CastingBarFrame.lua:309>
```

Line 722 is `for _, barTypeInfo in pairs(CastingBarTypeInfo) do`, which is not allowed once execution is tainted.

## Why

The frame erroring is `OverlayPlayerCastingBarFrame` - the bar Blizzard uses for the talent commit cast, crafting and the override bar. It registers the `UNIT_SPELLCAST_*` events in its `OnLoad` and therefore processes every player cast, shown or not.

When we replace the player cast bar we disable `PlayerCastingBarFrame` by reparenting it into `E.HiddenFrame`, which taints it. Blizzard's overlay bar then reaches straight into that frame:

```lua
function OverlayPlayerCastingBarMixin:StartReplacingPlayerBarAt(parentFrame, overrideInfo)
	-- Disable real Player Cast Bar
	PlayerCastingBarFrame:SetAndUpdateShowCastbar(false);

	overrideInfo = overrideInfo or {};
	self.overrideBarType = overrideInfo.overrideBarType;
```

Touching our tainted frame taints that execution, and the write that follows lands on `OverlayPlayerCastingBarFrame`, so it stays tainted from then on. Every later cast blows up inside its own event handler.

## The change

We are replacing the player cast bar anyway, so unregister the overlay bar's events next to where we already disable the player and pet bars.

`StartReplacingPlayerBarAt` never re-registers them - it does not call `SetUnit`, only `OnLoad` does - so the unregister holds. The talent frame already falls back to its commit spinner when the bar is not shown (`TalentFrameBaseMixin:SetCommitSpinnerShown` checks `OverlayPlayerCastingBarFrame:IsShown()`).

Deliberately not using `HideFrame` here: reparenting would fight the `SetParent` calls Blizzard makes in `StartReplacingPlayerBarAt`/`EndReplacingPlayerBar` and add taint for no gain.

Tradeoff: the small cast bar Blizzard overlays on the talent/crafting window no longer appears. Our own cast bar still shows the cast.

## Testing

Retail: spec swaps, talent commits, crafting and a long combat session no longer produce the error.
