### PR TITLE
Fix Masque skinning for retail player auras

### DIFF
--- a/ElvUI/Game/Shared/Modules/Auras/Auras.lua
+++ b/ElvUI/Game/Shared/Modules/Auras/Auras.lua
@@ -754,6 +754,9 @@ function A:Initialize()
 			buff.auraType = 'buffs'
 			buff.unit = 'player'
 			buff.filters = {}
+			if MasqueGroupBuffs and E.private.auras.masque.buffs then
+				buff.MasqueGroup = MasqueGroupBuffs
+			end
 
 			A.BuffFrame = buff
 
@@ -777,6 +780,9 @@ function A:Initialize()
 			debuff.auraType = 'debuffs'
 			debuff.unit = 'player'
 			debuff.filters = {}
+			if MasqueGroupDebuffs and E.private.auras.masque.debuffs then
+				debuff.MasqueGroup = MasqueGroupDebuffs
+			end
 
 			A.DebuffFrame = debuff
 


### PR DESCRIPTION
## Summary

- Attach the configured Masque groups to the new AuraContainer-based player buff and debuff frames on Retail.
- Restore the same Masque registration path already used by the legacy SecureAuraHeader implementation.

Without `container.MasqueGroup`, `E:Auras_UpdateButton` never registers the generated player aura buttons with Masque.

## Testing

Tested in-game on Retail 12.1.0 with ElvUI v15.24 and Masque 12.0.8. With Masque enabled for ElvUI buffs and debuffs, the selected skin is applied after reload.