### PR TITLE
skin: adjust debug scrollbar position

### DIFF
--- a/ElvUI/Game/Mainline/Skins/Debug.lua
+++ b/ElvUI/Game/Mainline/Skins/Debug.lua
@@ -30,8 +30,6 @@ local function SkinOnShow()
 	ScriptErrorsFrame.ScrollFrame:OffsetFrameLevel(2)
 
 	S:HandleTrimScrollBar(_G.ScriptErrorsFrame.ScrollFrame.ScrollBar)
-	ScriptErrorsFrame.ScrollFrame.ScrollBar:Point('TOPLEFT', ScriptErrorsFrame.ScrollFrame, 'TOPRIGHT', 4, 2)
-	ScriptErrorsFrame.ScrollFrame.ScrollBar:Point('BOTTOMLEFT', ScriptErrorsFrame.ScrollFrame, 'BOTTOMRIGHT', 4, 2)
 
 	for i = 1, #FrameTexs do
 		_G['ScriptErrorsFrame'..FrameTexs[i]]:SetTexture()


### PR DESCRIPTION
This adjusts the ScriptErrorsFrame's scrollbar position to its default position which adds a bit more spacing between the text and the scrollbar.
<img width="512" height="309" alt="before" src="https://github.com/user-attachments/assets/05bbba0a-634b-452e-a95c-1fe8b73ede36" />
<img width="511" height="314" alt="after" src="https://github.com/user-attachments/assets/83fdd5bc-f114-46d3-a458-4aebc34529cb" />
