### PR TITLE
Feature: Allow accepting of `0.1` decimals for movers.

### DIFF
--- a/ElvUI/Game/Shared/General/Config.lua
+++ b/ElvUI/Game/Shared/General/Config.lua
@@ -263,8 +263,8 @@ function E:UpdateNudgeFrame(mover, x, y)
 		x, y = E:CalculateMoverPoints(mover)
 	end
 
-	x = E:Round(x)
-	y = E:Round(y)
+	x = E:Round(x, 1)
+	y = E:Round(y, 1)
 
 	E.MoverNudgeFrame.xOffset:SetText(x)
 	E.MoverNudgeFrame.yOffset:SetText(y)
@@ -485,13 +485,13 @@ function E:CreateMoverPopup()
 	nudgeFrame:SetScript('OnKeyDown', function(_, btn)
 		local Mod = IsAltKeyDown() or IsControlKeyDown()
 		if btn == 'NUMPAD4' then
-			E:NudgeMover(-1 * (Mod and 10 or 1))
+			E:NudgeMover(-1 * (Mod and 10 or 0.1))
 		elseif btn == 'NUMPAD6' then
-			E:NudgeMover(1 * (Mod and 10 or 1))
+			E:NudgeMover(1 * (Mod and 10 or 0.1))
 		elseif btn == 'NUMPAD8' then
-			E:NudgeMover(nil, 1 * (Mod and 10 or 1))
+			E:NudgeMover(nil, 1 * (Mod and 10 or 0.1))
 		elseif btn == 'NUMPAD2' then
-			E:NudgeMover(nil, -1 * (Mod and 10 or 1))
+			E:NudgeMover(nil, -1 * (Mod and 10 or 0.1))
 		end
 	end)
 
@@ -524,7 +524,7 @@ function E:CreateMoverPopup()
 	xOffset:SetAutoFocus(false)
 	xOffset.currentValue = 0
 	xOffset:SetScript('OnEscapePressed', function(eb)
-		eb:SetText(E:Round(xOffset.currentValue))
+		eb:SetText(E:Round(xOffset.currentValue, 1))
 		EditBox_ClearFocus(eb)
 	end)
 
@@ -536,18 +536,18 @@ function E:CreateMoverPopup()
 			E:NudgeMover(diff)
 		end
 
-		eb:SetText(E:Round(xOffset.currentValue))
+		eb:SetText(E:Round(xOffset.currentValue, 1))
 		EditBox_ClearFocus(eb)
 	end)
 
 	xOffset:SetScript('OnEditFocusLost', function(eb)
-		eb:SetText(E:Round(xOffset.currentValue))
+		eb:SetText(E:Round(xOffset.currentValue, 1))
 	end)
 
 	xOffset:SetScript('OnEditFocusGained', EditBox_HighlightText)
 	xOffset:SetScript('OnShow', function(eb)
 		EditBox_ClearFocus(eb)
-		eb:SetText(E:Round(xOffset.currentValue))
+		eb:SetText(E:Round(xOffset.currentValue, 1))
 	end)
 
 	xOffset.text = xOffset:CreateFontString(nil, 'OVERLAY', 'GameFontNormal')
@@ -562,7 +562,7 @@ function E:CreateMoverPopup()
 	yOffset:SetAutoFocus(false)
 	yOffset.currentValue = 0
 	yOffset:SetScript('OnEscapePressed', function(eb)
-		eb:SetText(E:Round(yOffset.currentValue))
+		eb:SetText(E:Round(yOffset.currentValue, 1))
 		EditBox_ClearFocus(eb)
 	end)
 
@@ -574,18 +574,18 @@ function E:CreateMoverPopup()
 			E:NudgeMover(nil, diff)
 		end
 
-		eb:SetText(E:Round(yOffset.currentValue))
+		eb:SetText(E:Round(yOffset.currentValue, 1))
 		EditBox_ClearFocus(eb)
 	end)
 
 	yOffset:SetScript('OnEditFocusLost', function(eb)
-		eb:SetText(E:Round(yOffset.currentValue))
+		eb:SetText(E:Round(yOffset.currentValue, 1))
 	end)
 
 	yOffset:SetScript('OnEditFocusGained', EditBox_HighlightText)
 	yOffset:SetScript('OnShow', function(eb)
 		EditBox_ClearFocus(eb)
-		eb:SetText(E:Round(yOffset.currentValue))
+		eb:SetText(E:Round(yOffset.currentValue, 1))
 	end)
 
 	yOffset.text = yOffset:CreateFontString(nil, 'OVERLAY', 'GameFontNormal')

--- a/ElvUI/Game/Shared/General/Config.lua
+++ b/ElvUI/Game/Shared/General/Config.lua
@@ -485,13 +485,13 @@ function E:CreateMoverPopup()
 	nudgeFrame:SetScript('OnKeyDown', function(_, btn)
 		local Mod = IsAltKeyDown() or IsControlKeyDown()
 		if btn == 'NUMPAD4' then
-			E:NudgeMover(-1 * (Mod and 10 or 0.1))
+			E:NudgeMover(-0.1 * (Mod and 10 or 1))
 		elseif btn == 'NUMPAD6' then
-			E:NudgeMover(1 * (Mod and 10 or 0.1))
+			E:NudgeMover(1 * (Mod and 10 or 1))
 		elseif btn == 'NUMPAD8' then
-			E:NudgeMover(nil, 1 * (Mod and 10 or 0.1))
+			E:NudgeMover(nil, 1 * (Mod and 10 or 1))
 		elseif btn == 'NUMPAD2' then
-			E:NudgeMover(nil, -1 * (Mod and 10 or 0.1))
+			E:NudgeMover(nil, -1 * (Mod and 10 or 1))
 		end
 	end)
 

--- a/ElvUI/Game/Shared/General/Movers.lua
+++ b/ElvUI/Game/Shared/General/Movers.lua
@@ -35,7 +35,7 @@ local function GetPoint(obj)
 	local point, anchor, secondaryPoint, x, y = obj:GetPoint()
 	if not anchor then anchor = UIParent end
 
-	return format('%s,%s,%s,%d,%d', point, anchor:GetName(), secondaryPoint, x and E:Round(x) or 0, y and E:Round(y) or 0)
+	return format('%s,%s,%s,%.1f,%.1f', point, anchor:GetName(), secondaryPoint, x and E:Round(x, 1) or 0, y and E:Round(y, 1) or 0)
 end
 
 local function GetSettingPoints(text)


### PR DESCRIPTION
**Before**:
<img width="297" height="67" alt="image" src="https://github.com/user-attachments/assets/2ca20fc7-2485-4b57-9473-0b9ffbf6522f" />

**After**:
<img width="308" height="71" alt="image" src="https://github.com/user-attachments/assets/4e640d61-e017-429e-be32-49e36137163b" />

As you can see, the adjustment of `0.1` (or any decimal values), *should* hopefully be a sufficient workaround for the lack of pixel-snapping support.

Mousewheel adjustments, using the arrows on the mover panels still adjust for a whole value, I do not believe this is something that should be changed. This should only be used for an extra layer of fine-tuning.

The only *issue* I have encountered is that snapping / drag & drop of the movers will result in some `0.6` or `0.4` decimal points. I assume this would vary based on resolution. If you have a solution, happy to include.

Obviously, this is merely a suggested implementation. Anything you want changed / tweaked or if there's something I have missed, please let me know.